### PR TITLE
Only add drag&drop-delay if mobile-browser

### DIFF
--- a/resources/js/components/kanban/KanbanBoard.vue
+++ b/resources/js/components/kanban/KanbanBoard.vue
@@ -511,7 +511,8 @@ export default {
             columnDragOptions() {
                 return {
                   animation: 200,
-                  delay: 200,
+                  // checks if a mobile-browser is used and if true, add delay
+                  ...(/Mobi/i.test(window.navigator.userAgent) && {delay: 200}),
                   group: "column-list",
                   dragClass: "status-drag",
                   fallbackTolerance: 5,
@@ -521,7 +522,7 @@ export default {
             itemDragOptions() {
                 return {
                   animation: 200,
-                  delay: 200,
+                  ...(/Mobi/i.test(window.navigator.userAgent) && {delay: 200}),
                   group: "item-list",
                   dragClass: "status-drag",
                   fallbackTolerance: 5,


### PR DESCRIPTION
adds the delay-attribute conditionally.
can be tested by just using the device-toolbar in the developer-tools (top-left right beside the 'select an element to inspect')
=> by activating this, the user-agent changes to a mobile one. Only works when site gets loaded with a mobile user-agent