### PR TITLE
fixed kanban height for guest user | read comment

### DIFF
--- a/resources/js/components/kanban/KanbanBoard.vue
+++ b/resources/js/components/kanban/KanbanBoard.vue
@@ -556,7 +556,7 @@ export default {
 .content-only .kanban_board_container { width: calc(100vw - 1rem); }
 .kanban_board_wrapper {
     position:absolute;
-    /*height: 100%;*/
+    height: 100%;
     width: 100%;
     padding: 2rem;
     overflow:auto;

--- a/resources/js/components/kanban/KanbanItem.vue
+++ b/resources/js/components/kanban/KanbanItem.vue
@@ -38,7 +38,7 @@
                             class="dropdown-item py-1 text-red"
                             @click="confirmItemDelete()">
                             <i class="fa fa-trash mr-4"></i>
-                            {{ trans('global.delete') }}
+                            {{ trans('global.kanbanItem.delete') }}
                         </button>
                     </div>
                 </div>

--- a/resources/js/components/objectives/DropdownButton.vue
+++ b/resources/js/components/objectives/DropdownButton.vue
@@ -14,20 +14,20 @@
                  x-placement="top-start"
                  style="position: absolute; will-change: transform; top: 0px; left: 0px; transform: translate3d(0px, -2px, 0px);">
                 <span v-for="entry in Entries">
-                    <hr v-if="entry.hr === true ">
-                    <button v-else-if="entry.action === 'update' "
+                    <hr v-if="entry.hr === true" style="margin: 0.4rem 0;">
+                    <button v-else-if="entry.action === 'edit' "
                             class="dropdown-item"
                             @click="editObjective(entry)">
                         <i class="mr-4"
                            v-bind:class="entry.icon"></i>
-                        {{ entry.title }}
+                        {{ trans('global.terminalObjective.edit') }}
                     </button>
                     <button v-else-if="entry.action === 'move' "
                             class="dropdown-item"
                             @click="moveObjective(entry)">
                         <i class="mr-4"
                            v-bind:class="entry.icon"></i>
-                        {{ entry.title }}
+                        {{ trans('global.terminalObjective.move') }}
                     </button>
                     <button v-else-if="entry.action === 'resetOrderIds' "
                             class="dropdown-item"
@@ -37,10 +37,10 @@
                         {{ entry.title }}
                     </button>
                     <button v-else-if="entry.action === 'delete' "
-                            class="dropdown-item"
+                            class="dropdown-item text-danger"
                             @click="emitDeleteEvent()">
                         <i class="mr-4" v-bind:class="entry.icon"></i>
-                        {{ entry.title }}
+                        {{ trans('global.terminalObjective.delete') }}
                     </button>
                     <button v-else
                             class="dropdown-item"

--- a/resources/js/components/objectives/ObjectiveBox.vue
+++ b/resources/js/components/objectives/ObjectiveBox.vue
@@ -85,13 +85,13 @@ const Footer =
                     {
                       title: 'Edit',
                       icon: 'fa fa-edit',
-                      action: 'update',
+                      action: 'edit',
                       model: this.type+'Objectives',
                       value: this.type+'-objective-modal'
                     },
                     {
                         title: 'Move',
-                        icon: 'fa fa-arrows-alt',
+                        icon: 'fa fa-repeat',
                         action: 'move',
                         model: this.type+'Objectives',
                         value: 'move-'+this.type+'-objective-modal'
@@ -101,7 +101,7 @@ const Footer =
                     },
                     {
                       title: 'Delete',
-                      icon: 'fa fa-minus',
+                      icon: 'fa fa-trash',
                       action: 'delete',
                       model: this.type+'Objectives',
                     }

--- a/resources/lang/de/global.php
+++ b/resources/lang/de/global.php
@@ -515,7 +515,8 @@ return [
         'title_singular' => 'Bereich',
         'create' => 'Bereich erstellen',
         'edit' => 'Bereich bearbeiten',
-        'move_to_curriculum' => 'Bereich in anderes Curriculum verschieben',
+        'move' => 'Curriculum ändern',
+        'delete' => 'Bereich löschen',
         'fields' => [
             'time_approach' => 'Zeitansatz',
         ],

--- a/resources/lang/en/global.php
+++ b/resources/lang/en/global.php
@@ -512,7 +512,8 @@ return [
         'title_singular' => 'Terminal Objective',
         'create' => 'Create terminal objective',
         'edit' => 'Edit terminal objective',
-        'move_to_curriculum' => 'Move terminal objective to other curriculum',
+        'move' => 'Change Curriculum',
+        'delete' => 'Delete terminal objective',
         'fields' => [
             'time_approach' => 'Time approach',
         ],
@@ -856,9 +857,9 @@ return [
     'kanbanItem' => [
         'title' => 'Items',
         'title_singular' => 'Item',
-        'create' => 'Create items',
-        'edit' => 'Edit items',
-        'delete' => 'Delete items',
+        'create' => 'Create item',
+        'edit' => 'Edit item',
+        'delete' => 'Delete item',
         'delete_helper' => 'Should item be deleted?',
         'due_date' => 'Due-Date',
         'expired' => 'Expired',

--- a/resources/views/layouts/contentonly.blade.php
+++ b/resources/views/layouts/contentonly.blade.php
@@ -4,7 +4,7 @@
 @include('layouts.partials.head')
 
 <body class="hold-transition sidebar-mini layout-fixed layout-navbar-fixed content-only" >
-    <div id="app" class="wrapper">
+    <div id="app" class="d-flex flex-column flex-fill wrapper" style="height: 100vh">
         <!-- Navbar -->
         <nav class="main-header navbar navbar-expand navbar-lime navbar-light">
             <!-- Left navbar links -->
@@ -51,7 +51,7 @@
                 </div>
             </div><!-- /.container-fluid -->
         </section>
-        <div class="pl-2 pr-2" style="padding-bottom:50px">
+        <div class="d-flex flex-column flex-fill px-2">
             @yield('content')
             <input id="medium_id" class="invisible"> <!-- DONT REMOVE - used by TINYMCE -->
         </div>

--- a/resources/views/partials/footer.blade.php
+++ b/resources/views/partials/footer.blade.php
@@ -1,6 +1,6 @@
 @if(isset($contentonly))
 <footer class="main-footer py-1 no-print"
-        style="background-color:#737c83; position: fixed;left: 0;bottom: 0;width: 100%;margin-left:0 !important;" >
+        style="background-color: #737c83; width: 100%; margin-left: 0 !important;" >
 @else
 <footer class="main-footer py-1 no-print"
         style="background-color:#737c83">

--- a/resources/views/plans/create.blade.php
+++ b/resources/views/plans/create.blade.php
@@ -21,5 +21,5 @@
             ])
         </form>
     </div>
-</disv>
+</div>
 @endsection


### PR DESCRIPTION
changed the 'contentonly' blade-file, which gets loaded for guest-users.
I put the whole app-component in a display: flex, so it shouldn't matter which resolution the screen has.
Since I couldn't specifically find a fix for kanbans only, this is the best possible solution.

also fixed translation for KanbanItem-delete,
added translation into curricula-entry-options and fixed option-icons,
typo for a 'disv'