### PR TITLE
added datatable to videoconferences and auto-creates 2 token-links | fixes

### DIFF
--- a/app/Http/Controllers/ShareTokenController.php
+++ b/app/Http/Controllers/ShareTokenController.php
@@ -48,6 +48,7 @@ class ShareTokenController extends Controller
                 $field_model_id => $input['model_id'],
                 'subscribable_type' => "App\User",
                 'subscribable_id' => $user->id,
+                'editable' => $input['editable'] ?? false, // needed so there can be 2 token links
             ])->get()->first();
 
         if (isset($subscribe->sharing_token))
@@ -58,10 +59,11 @@ class ShareTokenController extends Controller
                 $field_model_id => $input['model_id'],
                 'subscribable_type' => "App\User",
                 'subscribable_id' => $user->id,
+                'editable' => $input['editable'] ?? false, // needed so there can be 2 token links
             ], [
                 'due_date' => $date,
-                'title' => isset($input['title']) ? $input['title'] : false,
-                'editable' => isset($input['editable']) ? $input['editable'] : false,
+                'title' => $input['title'] ?? false,
+                'editable' => $input['editable'] ?? false,
                 'owner_id' => auth()->user()->id,
                 'sharing_token' => $token,
             ]);
@@ -76,8 +78,8 @@ class ShareTokenController extends Controller
                 'sharing_token' => $token,
             ], [
                 'due_date' => $date,
-                'title' => isset($input['title']) ? $input['title'] : false,
-                'editable' => isset($input['editable']) ? $input['editable'] : false,
+                'title' => $input['title'] ?? false,
+                'editable' => $input['editable'] ?? false,
                 'owner_id' => auth()->user()->id,
             ]);
             $subscribe->save();

--- a/app/Http/Controllers/VideoconferenceController.php
+++ b/app/Http/Controllers/VideoconferenceController.php
@@ -166,6 +166,32 @@ class VideoconferenceController extends Controller
                 'owner_id' => auth()->user()->id,
             ]);
             $subscribe->save();
+        } else {
+            $guestToken = Str::uuid();
+            $modToken = Str::uuid();
+            $guest_id = User::find(env('GUEST_USER'))->id;
+
+            $subscribe = VideoconferenceSubscription::create([
+                'videoconference_id' => $videoconference->id,
+                'subscribable_type' => 'App\User',
+                'subscribable_id' => $guest_id,
+                'title' => 'Link für Gäste',
+                'editable' => false,
+                'owner_id' => auth()->user()->id,
+                'sharing_token' => $guestToken,
+            ]);
+            $subscribe->save();
+
+            $subscribe = VideoconferenceSubscription::create([
+                'videoconference_id' => $videoconference->id,
+                'subscribable_type' => 'App\User',
+                'subscribable_id' => $guest_id,
+                'title' => 'Link für Moderierende',
+                'editable' => true,
+                'owner_id' => auth()->user()->id,
+                'sharing_token' => $modToken,
+            ]);
+            $subscribe->save();
         }
 
 

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -190,8 +190,8 @@ Vue.component('color-picker-input', () => import('./components/kanban/ColorPicke
 Vue.component('leaflet-map', () => import('./components/map/Map.vue'));
 Vue.component('searchbar', () => import('./components/uiElements/Searchbar.vue'));
 Vue.component('date-picker-wrapper', () => import('./components/uiElements/DatePickerWrapper.vue'));
-Vue.component('videoconference', () => import('./components/videoconference/Videoconference'));
-Vue.component('videoconferences', () => import('./components/videoconference/Videoconferences'));
+Vue.component('videoconference', () => import('./components/videoconference/Videoconference.vue'));
+Vue.component('videoconferences', () => import('./components/videoconference/Videoconferences.vue'));
 
 Vue.component('tests-table', () => import('./components/tests/TestsTable.vue'));
 

--- a/resources/js/components/subscription/SubscribeModal.vue
+++ b/resources/js/components/subscription/SubscribeModal.vue
@@ -143,7 +143,7 @@
                             <label class="custom-control-label " for="canEditToken"></label>
                         </span>
                         <div>
-                            <button type="button" @click="createUserToken()" :disabled="nameToken == ''"
+                            <button type="button" @click="createUserToken()" :disabled="nameToken.trim() == ''"
                                     class="btn btn-sm btn-outline-success pull-right my-2">
                                 Speichern
                             </button>

--- a/resources/js/components/subscription/Tokens.vue
+++ b/resources/js/components/subscription/Tokens.vue
@@ -14,6 +14,9 @@
             class="item">
             <div class="d-flex flex-column">
                 <div>
+                    {{ item.token.title }}
+                </div>
+                <div>
                     <i class="fa fa-qrcode"
                         @click="setQRCodeId(item.token.id)"></i>
                     <span>

--- a/resources/js/components/videoconference/VideoconferenceCreate.vue
+++ b/resources/js/components/videoconference/VideoconferenceCreate.vue
@@ -163,7 +163,7 @@ export default {
                 'lockSettingsLockOnJoin': false,
                 'lockSettingsLockOnJoinConfigurable': false,
                 'guestPolicy': 'ALWAYS_ACCEPT',
-                'userName': '',
+                'userName': '', // TODO: where is this needed? | not in db
                 'meetingKeepEvents': false,
                 'endWhenNoModerator': false,
                 'endWhenNoModeratorDelayInMinutes': 1,

--- a/resources/js/components/videoconference/Videoconferences.vue
+++ b/resources/js/components/videoconference/Videoconferences.vue
@@ -1,14 +1,6 @@
 <template >
     <div class="row">
         <div class="col-md-12 py-2">
-<!--            <div id="videoconferences_filter" class="dataTables_filter">
-                <label >
-                    <input type="search"
-                           class="form-control form-control-sm"
-                           placeholder="Suchbegriff"
-                           v-model="search">
-                </label>
-            </div>-->
             <ul v-if="typeof (this.subscribable_type) == 'undefined' && typeof(this.subscribable_id) == 'undefined'"
                 class="nav nav-pills" role="tablist">
 <!--                <li v-can="'videoconference_create'"
@@ -68,7 +60,8 @@
             </ul>
         </div>
 
-        <div class="col-md-12 py-2">
+        <table id="videoconference-datatable" style="display: none;"></table>
+        <div id="videoconference-content" class="py-2">
             <div v-for="videoconference in videoconferences"
                  v-if="(videoconference.meetingName.toLowerCase().indexOf(search.toLowerCase()) !== -1)
                 || search.length < 3"
@@ -197,13 +190,15 @@ export default {
             } else {
                 this.url = '/videoconferences/list?filter=' + this.filter
             }
-            axios.get(this.url)
-                .then(response => {
-                    this.videoconferences = response.data.data;
-                })
-                .catch(e => {
-                    console.log(e);
-                });
+
+            $('#videoconfere-datatable').DataTable().ajax.url(this.url).load();
+            // axios.get(this.url)
+            //     .then(response => {
+            //         this.videoconferences = response.data.data;
+            //     })
+            //     .catch(e => {
+            //         console.log(e);
+            //     });
         },
         setFilter(filter){
             this.filter = filter;
@@ -225,13 +220,10 @@ export default {
                 });
         },
     },
-    created() {
-        document.getElementById('searchbar').classList.remove('d-none');
-    },
-
     mounted() {
-        const filters = ["all", "owner", "shared_with_me", "shared_by_me"];
+        document.getElementById('searchbar').classList.remove('d-none');
 
+        const filters = ["all", "owner", "shared_with_me", "shared_by_me"];
         let url = new URL(window.location.href);
         let urlFilter = url.searchParams.get("filter");
 
@@ -240,10 +232,8 @@ export default {
         }
 
         this.$eventHub.$on('filter', (filter) => {
-            this.search = filter;
+            $('#videoconference-datatable').DataTable().search(filter).draw();
         });
-
-        this.loaderEvent();
         this.$eventHub.$on('videoconference-added', (videoconference) => {
             this.videoconferences.push(videoconference);
         });
@@ -259,6 +249,66 @@ export default {
             //this.loaderEvent();
         });
 
+        const parent = this;
+        // checks if the datatable-data changes, to update the videoconference-data
+        $('#videoconference-datatable').on('draw.dt', () => {
+            parent.videoconferences = $('#videoconference-datatable').DataTable().rows({ page: 'current' }).data().toArray();
+        });
+
+        $('#videoconference-datatable').DataTable({
+            ajax: this.url + '?filter' + this.filter,
+            dom: 'tilpr',
+            columns: [
+                { title: 'id', data: 'id', searchable: false },
+                { title: 'meetingID', data: 'meetingID', searchable: false },
+                { title: 'meetingName', data: 'meetingName', searchable: true },
+                { title: 'attendeePW', data: 'attendeePW', searchable: false },
+                { title: 'moderatorPW', data: 'moderatorPW', searchable: false },
+                { title: 'endCallbackUrl', data: 'endCallbackUrl', searchable: false },
+                { title: 'welcomeMessage', data: 'welcomeMessage', searchable: true },
+                { title: 'dialNumber', data: 'dialNumber', searchable: false },
+                { title: 'maxParticipants', data: 'maxParticipants', searchable: false },
+                { title: 'logoutUrl', data: 'logoutUrl', searchable: false },
+                { title: 'record', data: 'record', searchable: false },
+                { title: 'duration', data: 'duration', searchable: false },
+                { title: 'isBreakout', data: 'isBreakout', searchable: false },
+                { title: 'moderatorOnlyMessage', data: 'moderatorOnlyMessage', searchable: false },
+                { title: 'autoStartRecording', data: 'autoStartRecording', searchable: false },
+                { title: 'allowStartStopRecording', data: 'allowStartStopRecording', searchable: false },
+                { title: 'bannerText', data: 'bannerText', searchable: false },
+                { title: 'bannerColor', data: 'bannerColor', searchable: false },
+                { title: 'logo', data: 'logo', searchable: false },
+                { title: 'copyright', data: 'copyright', searchable: false },
+                { title: 'muteOnStart', data: 'muteOnStart', searchable: false },
+                { title: 'allowModsToUnmuteUsers', data: 'allowModsToUnmuteUsers', searchable: false },
+                { title: 'lockSettingsDisableCam', data: 'lockSettingsDisableCam', searchable: false },
+                { title: 'lockSettingsDisableMic', data: 'lockSettingsDisableMic', searchable: false },
+                { title: 'lockSettingsDisablePrivateChat', data: 'lockSettingsDisablePrivateChat', searchable: false },
+                { title: 'lockSettingsDisablePublicChat', data: 'lockSettingsDisablePublicChat', searchable: false },
+                { title: 'lockSettingsDisableNote', data: 'lockSettingsDisableNote', searchable: false },
+                { title: 'lockSettingsLockedLayout', data: 'lockSettingsLockedLayout', searchable: false },
+                { title: 'lockSettingsLockOnJoin', data: 'lockSettingsLockOnJoin', searchable: false },
+                { title: 'lockSettingsLockOnJoinConfigurable', data: 'lockSettingsLockOnJoinConfigurable', searchable: false },
+                { title: 'guestPolicy', data: 'guestPolicy', searchable: false },
+                { title: 'meetingKeepEvents', data: 'meetingKeepEvents', searchable: false },
+                { title: 'endWhenNoModerator', data: 'endWhenNoModerator', searchable: false },
+                { title: 'endWhenNoModeratorDelayInMinutes', data: 'endWhenNoModeratorDelayInMinutes', searchable: false },
+                { title: 'meetingLayout', data: 'meetingLayout', searchable: false },
+                { title: 'learningDashboardCleanupDelayInMinutes', data: 'learningDashboardCleanupDelayInMinutes', searchable: false },
+                { title: 'allowModsToEjectCameras', data: 'allowModsToEjectCameras', searchable: false },
+                { title: 'allowRequestsWithoutSession', data: 'allowRequestsWithoutSession', searchable: false },
+                { title: 'userCameraCap', data: 'userCameraCap', searchable: false },
+                { title: 'allJoinAsModerator', data: 'allJoinAsModerator', searchable: false },
+                { title: 'medium_id', data: 'medium_id', searchable: false },
+                { title: 'webcamsOnlyForModerator', data: 'webcamsOnlyForModerator', searchable: false },
+                { title: 'anyoneCanStart', data: 'anyoneCanStart', searchable: false },
+            ],
+        });
+
+        // place the content where the table would normally be
+        setTimeout(() => {
+            $('#videoconference-content').insertBefore('#videoconference-datatable');
+        }, 250); // needs delay, because the wrapper only appears after receiving first ajax-response
     },
 
     components: {
@@ -267,3 +317,20 @@ export default {
     },
 }
 </script>
+<style>
+#videoconference-datatable_wrapper {
+    width: 100%;
+    padding: 0px 15px;
+}
+</style>
+<style scoped>
+.nav-link:hover {
+    cursor: default;
+    user-select: none;
+}
+
+.nav-item:hover .nav-link:not(.active) {
+    background-color: rgba(0, 0, 0, 0.1);
+    cursor: pointer;
+}
+</style>

--- a/resources/js/components/videoconference/Videoconferences.vue
+++ b/resources/js/components/videoconference/Videoconferences.vue
@@ -182,7 +182,7 @@ export default {
             //window.location = "/videoconferences/" + videoconference.id + "/edit";
         },
         shareVideoconference(videoconference){
-            this.$modal.show('subscribe-modal', { 'modelId': videoconference.id, 'modelUrl': 'videoconference' , 'shareWithToken': true, 'canEditLabel': 'darf Videoknferenz starten'});
+            this.$modal.show('subscribe-modal', { 'modelId': videoconference.id, 'modelUrl': 'videoconference' , 'shareWithToken': true, 'canEditLabel': 'darf Videokonferenz starten'});
         },
         loaderEvent(){
             if (typeof (this.subscribable_type) !== 'undefined' && typeof(this.subscribable_id) !== 'undefined'){
@@ -191,7 +191,7 @@ export default {
                 this.url = '/videoconferences/list?filter=' + this.filter
             }
 
-            $('#videoconfere-datatable').DataTable().ajax.url(this.url).load();
+            $('#videoconference-datatable').DataTable().ajax.url(this.url).load();
             // axios.get(this.url)
             //     .then(response => {
             //         this.videoconferences = response.data.data;

--- a/resources/views/layouts/contentonly.blade.php
+++ b/resources/views/layouts/contentonly.blade.php
@@ -45,7 +45,7 @@
                 </div>
             </div><!-- /.container-fluid -->
         </section>
-        <div class="d-flex flex-column flex-fill px-2">
+        <div class="d-flex flex-column flex-fill px-3">
             @yield('content')
             <input id="medium_id" class="invisible"> <!-- DONT REMOVE - used by TINYMCE -->
         </div>


### PR DESCRIPTION
fixes include: 
- videoconference components weren't correctly imported in app.js
- it was possible to try to create a token-link with a title containing only a space, which would result in a 422
- added title to the list of existing token-links
- typo
- added more padding in the 'contentonly'-layout, since the window-width would be 7px to wide, creating an unnecessary scrollbar (yes I added more padding to reduce the width)