### PR TITLE
fixes for colorization in logbooks/kanbans | others

### DIFF
--- a/app/Http/Controllers/LogbookController.php
+++ b/app/Http/Controllers/LogbookController.php
@@ -26,22 +26,20 @@ class LogbookController extends Controller
 
        $logbooks = Logbook::with('subscriptions');
 
-        if (!is_admin()) {
-            switch ($request->filter) {
-                case 'owner':
-                    $logbooks = $logbooks->where('owner_id', auth()->user()->id);
-                    break;
-                case 'shared_with_me':
-                    $logbooks = $this->getLogbooks(false);
-                    break;
-                case 'shared_by_me':
-                    $logbooks = $logbooks->where('owner_id', auth()->user()->id)->whereHas('subscriptions');
-                    break;
-                case 'all':
-                default:
-                    $logbooks = $this->getLogbooks();
-                    break;
-            }
+        switch ($request->filter) {
+            case 'owner':
+                $logbooks = $logbooks->where('owner_id', auth()->user()->id);
+                break;
+            case 'shared_with_me':
+                $logbooks = $this->getLogbooks(false);
+                break;
+            case 'shared_by_me':
+                $logbooks = $logbooks->where('owner_id', auth()->user()->id)->whereHas('subscriptions');
+                break;
+            case 'all':
+            default:
+                $logbooks = $this->getLogbooks();
+                break;
         }
 
 

--- a/resources/js/components/kanban/KanbanCreate.vue
+++ b/resources/js/components/kanban/KanbanCreate.vue
@@ -2,9 +2,12 @@
   <div class="modal fade">
     <div class="modal-dialog">
       <div class="modal-content">
-        <div class="modal-header bg-success">
-          <b class="modal-title">
+        <div class="modal-header">
+          <b v-if="this.method === 'post'" class="modal-title">
             {{ trans('global.kanban.create') }}
+          </b>
+          <b v-else>
+            {{ trans('global.kanban.edit') }}
           </b>
           <button
               type="button"

--- a/resources/js/components/kanban/KanbanIndexWidget.vue
+++ b/resources/js/components/kanban/KanbanIndexWidget.vue
@@ -19,8 +19,8 @@
       </div>
       <div v-else
            class="nav-item-box-image-size text-center"
-           :style="{backgroundColor: kanban.color + ' !important'}">
-        <i class="fa fa-2x p-5 fa-columns nav-item-text text-white"></i>
+           :style="'background-color: ' + (kanban.color ?? '#2980B9') + ' !important; color: ' + $textcolor(kanban.color) + ' !important;'">
+        <i class="fa fa-2x p-5 fa-columns nav-item-text"></i>
       </div>
 
       <span class="bg-white text-center p-1 overflow-auto nav-item-box">

--- a/resources/js/components/logbooks/LogbookCreate.vue
+++ b/resources/js/components/logbooks/LogbookCreate.vue
@@ -2,9 +2,12 @@
     <div class="modal fade">
         <div class="modal-dialog">
             <div class="modal-content">
-                <div class="modal-header bg-success">
-                    <b class="modal-title">
+                <div class="modal-header">
+                    <b v-if="this.method === 'post'" class="modal-title">
                         {{ trans('global.logbook.create') }}
+                    </b>
+                    <b v-else>
+                        {{ trans('global.logbook.edit') }}
                     </b>
                     <button
                         type="button"

--- a/resources/js/components/logbooks/LogbookIndexWidget.vue
+++ b/resources/js/components/logbooks/LogbookIndexWidget.vue
@@ -13,8 +13,8 @@
                 </div>
             </div>
             <div v-else class="nav-item-box-image-size text-center"
-                :style="{ backgroundColor: (logbook.color ?? '#2980B9') + ' !important' }">
-                <i :class="logbook.css_icon + ' fa-2x p-5 nav-item-text text-white'"></i>
+                :style="'background-color: ' + (logbook.color ?? '#2980B9') + ' !important; color: ' + $textcolor(logbook.color) + ' !important;'">
+                <i :class="logbook.css_icon + ' fa-2x p-5 nav-item-text'"></i>
             </div>
             <span class="bg-white text-center p-1 overflow-auto nav-item-box">
                 <h1 class="h6 events-heading pt-1 hyphens nav-item-text">

--- a/resources/js/components/logbooks/Logbooks.vue
+++ b/resources/js/components/logbooks/Logbooks.vue
@@ -97,7 +97,7 @@ export default {
             // always case insensitive
             const elements = this.$el.getElementsByClassName('box');
             const search = this.search.toLowerCase();
-            for (let i = 0; i < elements.length; i++) {
+            for (let i = 0; i < elements.length - 1; i++) {
                 const element = elements[i];
                 const content = element.innerText.toLowerCase();
 


### PR DESCRIPTION
others include:
- logbook filter now works for admins, was deactivated for admins before (why though?)
- added translation text in edit-modal for logbook/kanban
- search in logbooks doesn't hide the logbook-add-widget anymore

INFO: 
KanbansIndexWidget.vue has an event for 'filter' which doesn't get used, since the filtering is done in the Kanbans.vue by the DataTable itself.