### PR TITLE
improved plans | fixes | WIP

### DIFF
--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -214,6 +214,19 @@ class PlanController extends Controller
         return back();
     }
 
+    public function syncEntriesOrder(Plan $plan)
+    {
+        abort_unless(auth()->user()->id == $plan->owner_id, 403);
+
+        $input = $this->validateRequest();
+
+        $plan->update([
+            'entry_order' => $input['entry_order']
+        ]);
+
+        return ['entry_order' => $plan->entry_order];
+    }
+
     protected function validateRequest()
     {
         return request()->validate([
@@ -223,6 +236,7 @@ class PlanController extends Controller
             'end'           => 'sometimes',
             'duration'      => 'sometimes',
             'type_id'       => 'sometimes',
+            'entry_order'   => 'sometimes',
         ]);
     }
 }

--- a/app/Plan.php
+++ b/app/Plan.php
@@ -8,6 +8,10 @@ class Plan extends Model
 {
     protected $guarded = [];
 
+    protected $casts = [
+        'entry_order' => 'array',
+    ];
+
     protected $attributes = [
         'type_id' => 1,  //= Wochenplan
     ];

--- a/database/migrations/2023_12_15_065940_add_entry_order_to_plans.php
+++ b/database/migrations/2023_12_15_065940_add_entry_order_to_plans.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('plans', function (Blueprint $table) {
+            $table->json('entry_order')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('plans', function (Blueprint $table) {
+            $table->dropColumn('entry_order');
+        });
+    }
+};

--- a/resources/js/components/exercise/Exercises.vue
+++ b/resources/js/components/exercise/Exercises.vue
@@ -45,54 +45,65 @@
                     </div>
                 </div>
 
-                <div class="card-footer"
+                <div class="card-footer" role="button"
                      v-if="!editor &&  $userId == training.owner_id"
                      @click="edit()">
                     <i class="fa fa-add"></i> {{ trans('global.exercise.create') }}
                 </div>
 
-                <div v-if="editor "
-                     class="card-body">
-                    <div class="form-group">
-                        <input
-                            type="text"
-                            id="title"
-                            name="title"
-                            class="form-control"
-                            v-model.trim="form.title"
-                            :placeholder="trans('global.exercise.fields.title')"
-                            required
-                        />
-                        <p class="help-block" v-if="form.errors.title" v-text="form.errors.title[0]"></p>
-                    </div>
-
-                    <div class="form-group">
-                        <textarea
-                            :id="'description'+component_id"
-                            :name="'description'+component_id"
-                            :placeholder="trans('global.exercise.fields.description')"
-                            class="form-control description my-editor"
-                            v-model.trim="form.description"
-                        ></textarea>
-                        <p class="help-block" v-if="form.errors.description" v-text="form.errors.description[0]"></p>
-                    </div>
-
-                    <div class="form-group">
-                        <input
-                            type="number"
-                            id="recommended_iterations"
-                            name="recommended_iterations"
-                            class="form-control"
-                            v-model.trim="form.recommended_iterations"
-                            :placeholder="trans('global.exercise.fields.recommended_iterations')"
-                            required
-                        />
-                    </div>
-                    <button :name="'exerciseSave'"
-                            class="btn btn-primary p-2 m-2"
-                            @click="submit()">
-                        {{ trans('global.save') }}
-                    </button>
+                <div v-if="editor"
+                    class="card-body"
+                >
+                    <form class="needs-validation">
+                        <div class="form-group">
+                            <input
+                                type="text"
+                                id="title"
+                                name="title"
+                                class="form-control"
+                                v-model.trim="form.title"
+                                :placeholder="trans('global.exercise.fields.title')"
+                                required
+                            />
+                            <p class="help-block" v-if="form.errors.title" v-text="form.errors.title[0]"></p>
+                            <div class="invalid-feedback">
+                                {{ trans('global.invalid_form') }}
+                            </div>
+                        </div>
+    
+                        <div class="form-group">
+                            <textarea
+                                :id="'description'+component_id"
+                                :name="'description'+component_id"
+                                :placeholder="trans('global.exercise.fields.description')"
+                                class="form-control description my-editor"
+                                v-model.trim="form.description"
+                            ></textarea>
+                            <p class="help-block" v-if="form.errors.description" v-text="form.errors.description[0]"></p>
+                        </div>
+                            
+                        <div class="form-group">
+                            <input
+                                type="number"
+                                min="1"
+                                id="recommended_iterations"
+                                name="recommended_iterations"
+                                class="form-control"
+                                v-model.trim="form.recommended_iterations"
+                                :placeholder="trans('global.exercise.fields.recommended_iterations')"
+                                required
+                            />
+                            <div class="invalid-feedback">
+                                {{ trans('global.invalid_form') }}
+                            </div>
+                        </div>
+                        <button :name="'exerciseSave'"
+                                class="btn btn-primary p-2 m-2"
+                                @click.prevent="submit()"
+                        >
+                            {{ trans('global.save') }}
+                        </button>
+                    </form>
                 </div>
             </div>
         </div>
@@ -177,9 +188,10 @@ export default {
                     console.log(e);
                 });
         },
-
         submit() {
-            let method = this.method.toLowerCase();
+            if (!this.validate()) return;
+
+            const method = this.method.toLowerCase();
             this.form.description = tinyMCE.get('description'+this.component_id).getContent();
             this.form.training_id = this.training.id;
             this.form.order_id = this.exercises.length;
@@ -207,6 +219,17 @@ export default {
             this.form.description = '';
             this.form.recommended_iterations = '';
             this.form.order_id = null;
+        },
+        validate() {
+            const form = this.$el.querySelector('.needs-validation');
+
+            if (!form.checkValidity()) {
+                form.classList.add('was-validated')
+                return false;
+            } else {
+                form.classList.remove('was-validated')
+                return true;
+            }
         },
         toggle(id){
             if (this.toggle_id != id){

--- a/resources/js/components/objectives/Objectives.vue
+++ b/resources/js/components/objectives/Objectives.vue
@@ -9,7 +9,7 @@
                     <div class="card-tools pull-right">
                         <span v-if="is_owner()">
                             <a @click="destroy('terminal', subscription)" >
-                                <i class="fas fa-trash text-danger"></i>
+                                <i class="fas fa-trash text-danger pointer"></i>
                             </a>
                         </span>
                     </div>

--- a/resources/js/components/objectives/Objectives.vue
+++ b/resources/js/components/objectives/Objectives.vue
@@ -94,13 +94,13 @@ const EnablingObjectives =
         },
         methods: {
             loaderEvent() {
-                    axios.get('/terminalObjectiveSubscriptions?subscribable_type=' + this.referenceable_type + '&subscribable_id=' + this.referenceable_id)
-                        .then(response => {
-                            this.subscriptions = response.data.subscriptions;
-                        })
-                        .catch(e => {
-                            console.log(e);
-                        });
+                axios.get('/terminalObjectiveSubscriptions?subscribable_type=' + this.referenceable_type + '&subscribable_id=' + this.referenceable_id)
+                    .then(response => {
+                        this.subscriptions = response.data.subscriptions;
+                    })
+                    .catch(e => {
+                        console.log(e);
+                    });
                 axios.get('/enablingObjectiveSubscriptions?subscribable_type=' + this.referenceable_type + '&subscribable_id=' + this.referenceable_id)
                     .then(response => {
                         response.data.subscriptions.forEach(

--- a/resources/js/components/objectives/SubscribeObjectiveModal.vue
+++ b/resources/js/components/objectives/SubscribeObjectiveModal.vue
@@ -52,6 +52,7 @@
                             v-model="terminal_objective_id"
                             class="form-control select2"
                             style="width:100%;"
+                            :disabled="isEmpty(terminalObjectives) ? 'disabled' : null"
                     >
                         <option v-for="(item,index) in terminalObjectives" v-bind:value="item.id">{{ item.title }}</option>
                     </select>
@@ -66,6 +67,7 @@
                             v-model="enabling_objective_id"
                             class="form-control select2"
                             style="width:100%;"
+                            :disabled="isEmpty(enablingObjectives) ? 'disabled' : null"
                     >
                         <option v-for="(item,index) in enablingObjectives" v-bind:value="item.id">{{ item.title }}</option>
                     </select>
@@ -99,6 +101,9 @@
                 enabling_objective_id: null,
                 requestUrl: null
             };
+        },
+        mounted() {
+            this.loadCurricula();
         },
         methods: {
             async loadCurricula() {
@@ -151,19 +156,14 @@
                 }
             },
             beforeOpen(event) {
-                this.loadCurricula();
                 if (event.params.referenceable_type){
                     this.referenceable_type = event.params.referenceable_type;
                     this.referenceable_id = event.params.referenceable_id;
                 }
             },
-            beforeClose() {
-            },
-            opened(){
+            beforeClose() {},
+            opened() {
                 this.initSelect2();
-                this.curricula = {};
-                this.terminalObjectives = {};
-                this.enablingObjectives = {};
             },
             initSelect2(){
                 $("#curricula").select2({
@@ -202,8 +202,10 @@
                 for (let i = 0; i < array.length; i++) {
                     array[i].title = array[i].title.replace(/(<([^>]+)>)/ig, "");
                 }
-            }
-
+            },
+            isEmpty(obj) {
+                return $.isEmptyObject(obj);
+            },
         }
     }
 </script>

--- a/resources/js/components/objectives/SubscribeObjectiveModal.vue
+++ b/resources/js/components/objectives/SubscribeObjectiveModal.vue
@@ -124,7 +124,7 @@
                     this.errors = error.response.data.errors;
                 }
             },
-            loadEnabling(id){
+            loadEnabling(id) {
                 if (this.terminal_objective_id.length > 1) return;
 
                 this.enablingObjectives = this.terminalObjectives.find(terminal => terminal.id === parseInt(id)).enabling_objectives;
@@ -141,7 +141,7 @@
                     closeOnSelect: false,
                 });
             },
-            setEnabling(id){
+            setEnabling(id) {
                 this.enabling_objective_id.push(id);
                 this.requestUrl = '/enablingObjectiveSubscriptions';
             },
@@ -188,7 +188,7 @@
             opened() {
                 this.initSelect2();
             },
-            initSelect2(){
+            initSelect2() {
                 $("#curricula").select2({
                     dropdownParent: $(".v--modal-overlay"),
                     allowClear: false,
@@ -197,7 +197,8 @@
                     this.terminalObjectives = {};
                     this.enablingObjectives = {};
                     this.loadObjectives(e.params.data.id);
-                }.bind(this)); //make loadObjectives accessible!
+                }.bind(this));
+
                     
                 $("#terminalObjectives").select2({
                     dropdownParent: $(".v--modal-overlay"),
@@ -206,16 +207,27 @@
                 }).on('select2:select', function (e) {
                     this.enabling_objective_id = [];
                     this.enablingObjectives = {};
-                    this.terminal_objective_id.push(e.params.data.id);
-                    
+                    // if only 1 option is selected, close the dropdown
+                    if (this.terminal_objective_id.push(e.params.data.id) === 1) {
+                        $("#terminalObjectives").select2('close');
+                    }
                     this.loadEnabling(e.params.data.id);
-                }.bind(this)) //make loadEnabling accessible!
+                }.bind(this))
                 .on('select2:unselect', function (e) {
                     this.terminal_objective_id.splice(this.terminal_objective_id.findIndex(id => parseInt(id) == e.params.data.id), 1);
-
+                    // after removing an option, if 1 option is left selected, reload its enabling-objectives
                     if (this.terminal_objective_id.length === 1) this.loadEnabling(this.terminal_objective_id[0]);
                     else this.enablingObjectives = {};
-                }.bind(this));
+                    // prevent select2 toggling the dropdown after removing an option
+                    $("#terminalObjectives").data('unselecting', true);
+                }.bind(this))
+                .on('select2:opening', function (e) {
+                    if ($(this).data('unselecting')) {
+                        $(this).removeData('unselecting');
+                        e.preventDefault();
+                    }
+                });
+
 
                 $("#enablingObjectives").select2({
                     dropdownParent: $(".v--modal-overlay"),
@@ -223,16 +235,15 @@
                     closeOnSelect: false,
                 }).on('select2:select', function (e) {
                     this.setEnabling(e.params.data.id);
-                }.bind(this)) //make setEnabling accessible!
+                }.bind(this))
                 .on('select2:unselect', function (e) {
                     this.enabling_objective_id.splice(this.enabling_objective_id.findIndex(id => id == e.params.data.id), 1);
                 }.bind(this));
-
             },
-            close(){
+            close() {
                 this.$modal.hide('subscribe-objective-modal');
             },
-            removeHtmlTags(array, field){
+            removeHtmlTags(array, field) {
                 for (let i = 0; i < array.length; i++) {
                     array[i].title = array[i].title.replace(/(<([^>]+)>)/ig, "");
                 }

--- a/resources/js/components/objectives/SubscribeObjectiveModal.vue
+++ b/resources/js/components/objectives/SubscribeObjectiveModal.vue
@@ -52,7 +52,7 @@
                             v-model="terminal_objective_id"
                             class="form-control select2"
                             style="width:100%;"
-                            :disabled="isEmpty(terminalObjectives) ? 'disabled' : null"
+                            :disabled="isObjEmpty(terminalObjectives) ? 'disabled' : null"
                     >
                         <option v-for="(item,index) in terminalObjectives" v-bind:value="item.id">{{ item.title }}</option>
                     </select>
@@ -67,7 +67,7 @@
                             v-model="enabling_objective_id"
                             class="form-control select2"
                             style="width:100%;"
-                            :disabled="isEmpty(enablingObjectives) ? 'disabled' : null"
+                            :disabled="isObjEmpty(enablingObjectives) ? 'disabled' : null"
                     >
                         <option v-for="(item,index) in enablingObjectives" v-bind:value="item.id">{{ item.title }}</option>
                     </select>
@@ -203,7 +203,7 @@
                     array[i].title = array[i].title.replace(/(<([^>]+)>)/ig, "");
                 }
             },
-            isEmpty(obj) {
+            isObjEmpty(obj) { // needs wrapper function, since jQuery can't be referenced in HTML
                 return $.isEmptyObject(obj);
             },
         }

--- a/resources/js/components/objectives/SubscribeObjectiveModal.vue
+++ b/resources/js/components/objectives/SubscribeObjectiveModal.vue
@@ -52,6 +52,7 @@
                             v-model="terminal_objective_id"
                             class="form-control select2"
                             style="width:100%;"
+                            multiple="multiple"
                             :disabled="isObjEmpty(terminalObjectives) ? 'disabled' : null"
                     >
                         <option v-for="(item,index) in terminalObjectives" v-bind:value="item.id">{{ item.title }}</option>
@@ -67,6 +68,7 @@
                             v-model="enabling_objective_id"
                             class="form-control select2"
                             style="width:100%;"
+                            multiple="multiple"
                             :disabled="isObjEmpty(enablingObjectives) ? 'disabled' : null"
                     >
                         <option v-for="(item,index) in enablingObjectives" v-bind:value="item.id">{{ item.title }}</option>
@@ -95,10 +97,10 @@
                 curriculum_id: null,
                 terminalObjectives: {},
                 terminalObjective: {},
-                terminal_objective_id: null,
+                terminal_objective_id: [],
                 enablingObjectives: {},
                 enablingObjective: {},
-                enabling_objective_id: null,
+                enabling_objective_id: [],
                 requestUrl: null
             };
         },
@@ -112,8 +114,6 @@
                 } catch(error) {
                     this.errors = error.response.data.errors;
                 }
-                this.terminal_objective_id = null; //reset selection
-                this.enabling_objective_id = null;
             },
             async loadObjectives(id) {
                 this.curriculum_id = parseInt(id);
@@ -125,10 +125,16 @@
                 }
             },
             loadEnabling(id){
-                this.terminal_objective_id = parseInt(id);
+                this.terminal_objective_id.push(id);
+
+                if (this.terminal_objective_id.length > 1) return;
+
                 this.enablingObjectives = this.terminalObjectives.find(terminal => terminal.id === parseInt(id)).enabling_objectives;
                 this.removeHtmlTags(this.enablingObjectives);
                 this.requestUrl = '/terminalObjectiveSubscriptions';
+                
+                // needs to be cleared, else the selected option will appear on other objectives
+                $("#enablingObjectives").val(null).trigger('change');
                 // this select2 needs to be reinitialized, else it won't update the select-options
                 // the 'on:select' is still functionable
                 $("#enablingObjectives").select2({
@@ -137,7 +143,7 @@
                 });
             },
             setEnabling(id){
-                this.enabling_objective_id = parseInt(id);
+                this.enabling_objective_id.push(id);
                 this.requestUrl = '/enablingObjectiveSubscriptions';
             },
             async submit() {
@@ -170,7 +176,7 @@
                     dropdownParent: $(".v--modal-overlay"),
                     allowClear: false
                 }).on('select2:select', function (e) {
-                    this.terminal_objective_id = null;
+                    this.terminal_objective_id = [];
                     this.terminalObjectives = {};
                     this.enablingObjectives = {};
                     this.loadObjectives(e.params.data.id);
@@ -180,10 +186,8 @@
                     dropdownParent: $(".v--modal-overlay"),
                     allowClear: false
                 }).on('select2:select', function (e) {
-                    this.enabling_objective_id = null;
+                    this.enabling_objective_id = [];
                     this.enablingObjectives = {};
-                    // needs to be cleared, else the selected option will appear on other objectives
-                    $("#enablingObjectives").val(null).trigger('change');
                     this.loadEnabling(e.params.data.id);
                 }.bind(this)); //make loadEnabling accessible!
 

--- a/resources/js/components/objectives/SubscribeObjectiveModal.vue
+++ b/resources/js/components/objectives/SubscribeObjectiveModal.vue
@@ -71,8 +71,8 @@
 
             </div>
             <div class="card-footer">
-                <span class="pull-right">
-                     <button type="button" class="btn btn-primary" data-widget="remove" @click="close()">{{ trans('global.close') }}</button>
+                <span class="d-flex justify-content-between">
+                     <button type="button" class="btn btn-default" data-widget="remove" @click="close()">{{ trans('global.close') }}</button>
                      <button class="btn btn-primary" @click="submit()" >{{ trans('global.save') }}</button>
                 </span>
             </div>
@@ -129,12 +129,12 @@
                 this.terminal_objective_id = parseInt(id);
                 this.enabling_objective_id = terminal[0].enabling_objectives[0].id;
                 this.requestUrl = '/terminalObjectiveSubscriptions';
-                this.initSelect2();
+                // this.initSelect2();
             },
             setEnabling(id){
                 this.enabling_objective_id = parseInt(id);
                 this.requestUrl = '/enablingObjectiveSubscriptions';
-                this.initSelect2();
+                // this.initSelect2();
             },
             async submit() {
                 try {
@@ -151,14 +151,13 @@
                     //
                 }
             },
-
             beforeOpen(event) {
                 this.loadCurricula();
                 if (event.params.referenceable_type){
                     this.referenceable_type = event.params.referenceable_type;
                     this.referenceable_id = event.params.referenceable_id;
                 }
-             },
+            },
             beforeClose() {
             },
             opened(){

--- a/resources/js/components/objectives/TerminalObjectiveModal.vue
+++ b/resources/js/components/objectives/TerminalObjectiveModal.vue
@@ -208,10 +208,10 @@ const ColorPicker =
 
                 if (method === 'patch') {
                     this.form.patch( this.requestUrl + '/' + this.form.id)
-                        .then(response => this.$eventHub.$emit("addTerminalObjective", response.message));
+                        .then(response => this.$eventHub.$emit('addTerminalObjective', response.message));
                 } else {
                     this.form.post(this.requestUrl)
-                        .then(response => this.$eventHub.$emit("addTerminalObjective", response.message));
+                        .then(response =>  this.$eventHub.$emit('addTerminalObjective', response.message));
                 }
                 this.close();
 

--- a/resources/js/components/objectives/TerminalObjectives.vue
+++ b/resources/js/components/objectives/TerminalObjectives.vue
@@ -102,134 +102,134 @@ const draggable =
     import EnablingObjectives from './EnablingObjectives'
     import draggable from "vuedraggable"; // import the vuedraggable*/
 
-    export default {
-        props: {
-            'curriculum': Object,
-            'objectivetypes': Array,
-        },
-        data() {
-            return {
-                settings: {
-                    'last': null,
-                },
-                max_ids: {},
-                typetabs: {},
-                activetab: null,
-                currentCurriculaEnrolments: null,
-                errors: {},
-
-                terminal_objectives: Object
-            }
-        },
-        methods: {
-            filterTerminalObjectives(typetab) {
-                let filteredTerminalObjectives = this.terminal_objectives;
-                filteredTerminalObjectives = filteredTerminalObjectives.filter(
-                    t => t.objective_type_id === typetab
-                  );
-                this.max_ids[typetab] = filteredTerminalObjectives[filteredTerminalObjectives.length-1].id;
-                return filteredTerminalObjectives;
+export default {
+    props: {
+        'curriculum': Object,
+        'objectivetypes': Array,
+    },
+    data() {
+        return {
+            settings: {
+                'last': null,
             },
-            getTypeTitle(id){
-                return this.objectivetypes.filter(
-                    t => t.id === id
+            max_ids: {},
+            typetabs: {},
+            activetab: null,
+            currentCurriculaEnrolments: null,
+            errors: {},
+
+            terminal_objectives: Object
+        }
+    },
+    methods: {
+        filterTerminalObjectives(typetab) {
+            let filteredTerminalObjectives = this.terminal_objectives;
+            filteredTerminalObjectives = filteredTerminalObjectives.filter(
+                t => t.objective_type_id === typetab
                 );
-            },
-            setActiveTab(typetab){
-                this.activetab = typetab;
-            },
-            loadObjectives(objective_type_id = 0){
-                axios.get('/curricula/' + this.curriculum.id + '/objectives' )
-                    .then(response => {
-                        this.terminal_objectives = response.data.curriculum.terminal_objectives;
-                        if (this.terminal_objectives.length !== 0){
-                            this.settings.last = this.terminal_objectives[this.terminal_objectives.length-1].id;
-                            this.typetabs = [ ... new Set(this.terminal_objectives.map(t => t.objective_type_id))];
-                            if (!!this.curriculum.objective_type_order){
-                                if (this.curriculum.objective_type_order.length ===  this.typetabs.length){
-                                    this.typetabs = this.curriculum.objective_type_order;
-                                }
-                            }
-
-                            if (objective_type_id === 0){
-                                this.activetab = this.typetabs[0];
+            this.max_ids[typetab] = filteredTerminalObjectives[filteredTerminalObjectives.length-1].id;
+            return filteredTerminalObjectives;
+        },
+        getTypeTitle(id){
+            return this.objectivetypes.filter(
+                t => t.id === id
+            );
+        },
+        setActiveTab(typetab){
+            this.activetab = typetab;
+        },
+        loadObjectives(objective_type_id = 0){
+            axios.get('/curricula/' + this.curriculum.id + '/objectives' )
+                .then(response => {
+                    this.terminal_objectives = response.data.curriculum.terminal_objectives;
+                    if (this.terminal_objectives.length !== 0){
+                        this.settings.last = this.terminal_objectives[this.terminal_objectives.length-1].id;
+                        this.typetabs = [ ... new Set(this.terminal_objectives.map(t => t.objective_type_id))];
+                        if (!!this.curriculum.objective_type_order){
+                            if (this.curriculum.objective_type_order.length ===  this.typetabs.length){
+                                this.typetabs = this.curriculum.objective_type_order;
                             }
                         }
-                    })
-                    .catch(e => {
-                        this.errors = e.data.errors;
-                    });
-            },
-            externalEvent: function(ids) {
-                this.reloadEnablingObjectives(ids);
-            },
-            async reloadEnablingObjectives(ids) {
-                try {
-                    this.terminal_objectives = (await axios.post('/curricula/'+this.curriculum.id+'/achievements', {'user_ids' : ids})).data.curriculum.terminal_objectives;
-                } catch(error) {
-                    this.errors = error.response.data.errors;
-                }
-            },
 
-            checkCrossReferenceInLocalStorage(){
-                if (localStorage.getItem( 'currentCurriculaEnrolmentSelectorValue' ) !== null){
-                    $("#currentCurriculaEnrolmentSelector").val(localStorage.getItem( 'currentCurriculaEnrolmentSelectorValue' )).trigger('change');
-                    this.$parent.setCrossReferenceCurriculumId($("#currentCurriculaEnrolmentSelector").val());
-                } else {
-                    $("#currentCurriculaEnrolmentSelector").val(null).trigger('change');
-                }
-            },
-            handleTypeMoved() {
-                // Send the entire list of statuses to the server
-                axios.put("/curricula/"+this.curriculum.id+"/syncObjectiveTypesOrder", {objective_type_order: this.typetabs})
-                    .catch(err => {
-                        console.log(err.response);
-                        alert(err.response.statusText);
-                    });
-            },
-        },
-        mounted() {
-            this.settings = this.$attrs.settings;
-            this.loadObjectives();
-
-            //load users curricula for cross reference selector
-            axios.get('/curricula/references')
-                .then(response => {
-                    this.currentCurriculaEnrolments = response.data.message;
-                    this.$nextTick(() => {
-                        $("#currentCurriculaEnrolmentSelector").select2({
-                            value: null,
-                            placeholder: "Querverweise",
-                            allowClear: true
-                        }).on('select2:select', function () {
-                            localStorage.setItem( 'currentCurriculaEnrolmentSelectorValue', $("#currentCurriculaEnrolmentSelector").val() );
-                            this.$parent.setCrossReferenceCurriculumId($("#currentCurriculaEnrolmentSelector").val());
-                        }.bind(this))
-                        .on('select2:clear', function () {
-                            this.$parent.setCrossReferenceCurriculumId(false);
-                            localStorage.removeItem( 'currentCurriculaEnrolmentSelectorValue');
-                        }.bind(this));
-                       this.checkCrossReferenceInLocalStorage(); // load value from localStorage
-                    })
+                        if (objective_type_id === 0){
+                            this.activetab = this.typetabs[0];
+                        }
+                    }
                 })
                 .catch(e => {
                     this.errors = e.data.errors;
                 });
-
-            //eventlistener
-            this.$eventHub.$on('addEnablingObjective', (newEnablingObjective) => {
-                this.loadObjectives(this.activetab);
-            });
-            this.$eventHub.$on('addTerminalObjective', (newTerminalObjective) => {
-                this.activetab = newTerminalObjective.objective_type_id;
-                this.loadObjectives(this.activetab);
-            });
+        },
+        externalEvent: function(ids) {
+            this.reloadEnablingObjectives(ids);
+        },
+        async reloadEnablingObjectives(ids) {
+            try {
+                this.terminal_objectives = (await axios.post('/curricula/'+this.curriculum.id+'/achievements', {'user_ids' : ids})).data.curriculum.terminal_objectives;
+            } catch(error) {
+                this.errors = error.response.data.errors;
+            }
         },
 
-        components: {
-            ObjectiveBox,
-            EnablingObjectives,
-            draggable
-        }
+        checkCrossReferenceInLocalStorage(){
+            if (localStorage.getItem( 'currentCurriculaEnrolmentSelectorValue' ) !== null){
+                $("#currentCurriculaEnrolmentSelector").val(localStorage.getItem( 'currentCurriculaEnrolmentSelectorValue' )).trigger('change');
+                this.$parent.setCrossReferenceCurriculumId($("#currentCurriculaEnrolmentSelector").val());
+            } else {
+                $("#currentCurriculaEnrolmentSelector").val(null).trigger('change');
+            }
+        },
+        handleTypeMoved() {
+            // Send the entire list of statuses to the server
+            axios.put("/curricula/"+this.curriculum.id+"/syncObjectiveTypesOrder", {objective_type_order: this.typetabs})
+                .catch(err => {
+                    console.log(err.response);
+                    alert(err.response.statusText);
+                });
+        },
+    },
+    mounted() {
+        this.settings = this.$attrs.settings;
+        this.loadObjectives();
+
+        //load users curricula for cross reference selector
+        axios.get('/curricula/references')
+            .then(response => {
+                this.currentCurriculaEnrolments = response.data.message;
+                this.$nextTick(() => {
+                    $("#currentCurriculaEnrolmentSelector").select2({
+                        value: null,
+                        placeholder: "Querverweise",
+                        allowClear: true
+                    }).on('select2:select', function () {
+                        localStorage.setItem( 'currentCurriculaEnrolmentSelectorValue', $("#currentCurriculaEnrolmentSelector").val() );
+                        this.$parent.setCrossReferenceCurriculumId($("#currentCurriculaEnrolmentSelector").val());
+                    }.bind(this))
+                    .on('select2:clear', function () {
+                        this.$parent.setCrossReferenceCurriculumId(false);
+                        localStorage.removeItem( 'currentCurriculaEnrolmentSelectorValue');
+                    }.bind(this));
+                    this.checkCrossReferenceInLocalStorage(); // load value from localStorage
+                })
+            })
+            .catch(e => {
+                this.errors = e.data.errors;
+            });
+
+        //eventlistener
+        this.$on('addTerminalObjective', function(newTerminalObjective) {
+            this.activetab = newTerminalObjective.objective_type_id;
+            this.loadObjectives(this.activetab);
+        });
+        this.$on('addEnablingObjective', function(newEnablingObjective) {
+            this.loadObjectives(this.activetab);
+        });
+    },
+
+    components: {
+        ObjectiveBox,
+        EnablingObjectives,
+        draggable
     }
+}
 </script>

--- a/resources/js/components/plan/Plan.vue
+++ b/resources/js/components/plan/Plan.vue
@@ -4,12 +4,19 @@
 
         <div class="col-12 pt-2">
             <!-- Bewegungsfeld -->
-            <PlanEntry
-                v-for="(entry, index) in entries"
-                v-bind:key="entry.id"
-                :entry="entry"
-                :plan="plan"
-            ></PlanEntry>
+            <draggable
+                v-can="'plan_edit'"
+                v-model="entry_order"
+                @start="drag=true"
+                @end="handleEntryOrder"
+            >
+                <PlanEntry
+                    v-for="(value, index) in entry_order"
+                    v-bind:key="entries[index].id"
+                    :entry="entries[index]"
+                    :plan="plan"
+                ></PlanEntry>
+            </draggable>
         </div>
 
         <div class="col-12">
@@ -29,6 +36,8 @@
 </template>
 
 <script>
+import draggable from 'vuedraggable';
+
 const Calendar =
     () => import('../calendar/Calendar');
 const PlanEntry =
@@ -40,8 +49,8 @@ export default {
     },
     data() {
         return {
-            plans: [],
             entries: [],
+            entry_order: [],
             subscriptions: {},
             search: '',
             errors: {},
@@ -51,19 +60,50 @@ export default {
         loaderEvent(){
             axios.get('/planEntries?plan_id=' + this.plan.id)
                 .then(response => {
-                    this.entries = response.data.entries;
+                    if (this.plan.entry_order != null) {
+                        this.entry_order = this.plan.entry_order
+                        this.entries = this.entry_order.map(
+                            order_id => response.data.entries.find(entry => entry.id === order_id)
+                        );
+                    } else {
+                        this.entries = response.data.entries;
+                        this.entry_order = this.entries.map(entry => entry.id);
+                    }
                 })
                 .catch(e => {
                     console.log(e);
                 });
         },
+        handleEntryAdded(entry) {
+            this.entries.push(entry);
+            this.entry_order.push(entry.id);
+            this.handleEntryOrder();
+        },
         handleEntryDeleted(entry){
             let index = this.entries.indexOf(entry);
             this.entries.splice(index, 1);
+            this.entry_order.splice(index, 1);
+            this.updateEntryOrder();
         },
         //? maybe put event in Objectives.vue
         handleObjectiveAdded(objective, entryId) {
             const entry = this.entries.find(entry => entry.id === entryId);
+        },
+        handleEntryOrder() {
+            // rearrange entries to the specified order by ID
+            // since this is O[n^2], it could be a performance problem in the future
+            this.entries = this.entry_order.map(
+                order_id => this.entries.find(entry => entry.id === order_id)
+            );
+            this.updateEntryOrder();
+        },
+        updateEntryOrder() {
+            // Send the current order of entries to the server
+            axios.put("/plans/" + this.plan.id + "/syncEntriesOrder", {entry_order: this.entry_order})
+                .catch(err => {
+                    console.log(err.response);
+                    alert(err.response.statusText);
+                });
         },
     },
     mounted() {
@@ -71,7 +111,7 @@ export default {
         this.loaderEvent();
         this.entries = this.plan.entries;
         this.$eventHub.$on('plan_entry_added', (e) => {
-            this.loaderEvent();
+            this.handleEntryAdded();
         });
         this.$eventHub.$on('plan_entry_updated', (e) => {
             this.loaderEvent();
@@ -85,7 +125,8 @@ export default {
     },
     components: {
         Calendar,
-        PlanEntry
+        PlanEntry,
+        draggable
     },
 }
 </script>

--- a/resources/js/components/plan/Plan.vue
+++ b/resources/js/components/plan/Plan.vue
@@ -34,54 +34,58 @@ const Calendar =
 const PlanEntry =
     () => import('./PlanEntry');
 
-    export default {
-        props: {
-            plan: [],
-
-              },
-        data() {
-            return {
-                plans: [],
-                entries: [],
-                subscriptions: {},
-                search: '',
-                errors: {}
-            }
+export default {
+    props: {
+        plan: [],
+    },
+    data() {
+        return {
+            plans: [],
+            entries: [],
+            subscriptions: {},
+            search: '',
+            errors: {},
+        }
+    },
+    methods: {
+        loaderEvent(){
+            axios.get('/planEntries?plan_id=' + this.plan.id)
+                .then(response => {
+                    this.entries = response.data.entries;
+                })
+                .catch(e => {
+                    console.log(e);
+                });
         },
-        methods: {
-            loaderEvent(){
-                axios.get('/planEntries?plan_id=' + this.plan.id)
-                    .then(response => {
-                        this.entries = response.data.entries;
-                    })
-                    .catch(e => {
-                        console.log(e);
-                    });
-            },
-
-            handleEntryDeleted(entry){
-                let index = this.entries.indexOf(entry);
-                this.entries.splice(index, 1);
-            },
+        handleEntryDeleted(entry){
+            let index = this.entries.indexOf(entry);
+            this.entries.splice(index, 1);
         },
-
-        mounted() {
-            localStorage.removeItem('user-datatable-selection'); //reset selection to prevent wrong inputs
+        //? maybe put event in Objectives.vue
+        handleObjectiveAdded(objective, entryId) {
+            const entry = this.entries.find(entry => entry.id === entryId);
+        },
+    },
+    mounted() {
+        localStorage.removeItem('user-datatable-selection'); //reset selection to prevent wrong inputs
+        this.loaderEvent();
+        this.entries = this.plan.entries;
+        this.$eventHub.$on('plan_entry_added', (e) => {
             this.loaderEvent();
-            this.entries = this.plan.entries;
-            this.$eventHub.$on('plan_entry_added', (e) => {
-                this.loaderEvent();
-            });
-            this.$eventHub.$on('plan_entry_updated', (e) => {
-                this.loaderEvent();
-            });
-            this.$eventHub.$on('plan_entry_deleted', (e) => {
-                this.handleEntryDeleted();
-            });
-        },
-        components: {
-            Calendar,
-            PlanEntry
-        },
-    }
+        });
+        this.$eventHub.$on('plan_entry_updated', (e) => {
+            this.loaderEvent();
+        });
+        this.$eventHub.$on('plan_entry_deleted', (e) => {
+            this.handleEntryDeleted();
+        });
+        this.$eventHub.$on('objective_added', (objective, entryId) => {
+            this.handleObjectiveAdded(objective, entryId);
+        });
+    },
+    components: {
+        Calendar,
+        PlanEntry
+    },
+}
 </script>

--- a/resources/js/components/plan/PlanEntry.vue
+++ b/resources/js/components/plan/PlanEntry.vue
@@ -13,10 +13,11 @@
                     <div :id="'plan-entry-' + entry.id"
                          v-if="!editor"
                          :style="{ 'border-left-style': 'solid', 'border-radius': '0.25rem', 'border-color': entry.color }">
-                        <div class="card-header" data-toggle="collapse" :data-target="'#plan-entry-' + entry.id + ' > .card-body'" aria-expanded="true">
+                        <div class="card-header collapsed" data-toggle="collapse" :data-target="'#plan-entry-' + entry.id + ' > .card-body'" aria-expanded="false">
                             <i class="mr-1"
                             :class="entry.css_icon"></i>
                             {{ entry.title }}
+                            <i class="fa fa-angle-up"></i>
                             <div v-if="$userId == plan.owner_id"
                                 class="card-tools">
                                 <i class="fa fa-pencil-alt mr-2 pointer link-muted"
@@ -233,5 +234,11 @@ export default {
 .card-header:hover {
     background-color: #e9ecef;
     cursor: pointer;
+}
+.card-header .fa-angle-up {
+    transition: 0.3s transform;
+}
+.card-header.collapsed .fa-angle-up {
+    transform: rotate(-180deg);
 }
 </style>

--- a/resources/js/components/plan/PlanEntry.vue
+++ b/resources/js/components/plan/PlanEntry.vue
@@ -13,36 +13,36 @@
                     <div :id="'plan-entry-' + entry.id"
                          v-if="!editor"
                          :style="{ 'border-left-style': 'solid', 'border-radius': '0.25rem', 'border-color': entry.color }">
-                        <div class="card-header">
+                        <div class="card-header" data-toggle="collapse" :data-target="'#plan-entry-' + entry.id + ' > .card-body'" aria-expanded="true">
                             <i class="mr-1"
                             :class="entry.css_icon"></i>
                             {{ entry.title }}
                             <div v-if="$userId == plan.owner_id"
                                 class="card-tools">
-                                <i class="fa fa-pencil-alt mr-2 pointer text-muted"
+                                <i class="fa fa-pencil-alt mr-2 pointer link-muted"
                                    @click="edit()"></i>
                                 <i class="fas fa-trash pointer text-danger"
                                    @click="destroy(entry)"></i>
                             </div>
                         </div>
-                        <div class="card-body py-2">
+                        <div class="card-body py-2 collapse show">
                             <img v-if="Number.isInteger(entry.medium_id)"
                                  class="pull-right"
                                  :src="'/media/' + entry.medium_id + '/thumb'"/>
                             <span v-html="entry.description"></span>
+
+                            <objectives
+                                referenceable_type="App\PlanEntry"
+                                :referenceable_id="entry.id"
+                                :owner_id="entry.owner_id"
+                            ></objectives>
+    
+                            <Trainings
+                                :plan="plan"
+                                subscribable_type="App\PlanEntry"
+                                :subscribable_id="entry.id"
+                            ></Trainings>
                         </div>
-
-                        <objectives
-                            referenceable_type="App\PlanEntry"
-                            :referenceable_id="entry.id"
-                            :owner_id="entry.owner_id"
-                        ></objectives>
-
-                        <Trainings
-                            :plan="plan"
-                            subscribable_type="App\PlanEntry"
-                            :subscribable_id="entry.id"
-                        ></Trainings>
                     </div>
                 </div>
                 <div v-if="editor"
@@ -233,3 +233,9 @@ export default {
     },
 }
 </script>
+<style scoped>
+.card-header:hover {
+    background-color: #e9ecef;
+    cursor: pointer;
+}
+</style>

--- a/resources/js/components/plan/PlanEntry.vue
+++ b/resources/js/components/plan/PlanEntry.vue
@@ -131,7 +131,7 @@ export default {
                 'plan_id': '',
                 'css_icon': 'fas fa-calendar-day',
                 'order_id': 0,
-                'color': '#F4F4F4',
+                'color': '#27AF60',
                 'medium_id': null,
 
             }),

--- a/resources/js/components/plan/PlanEntry.vue
+++ b/resources/js/components/plan/PlanEntry.vue
@@ -173,10 +173,8 @@ export default {
     },
     methods: {
         setIcon(selectedIcon) {
-            console.log('selected', selectedIcon);
             this.form.css_icon = 'fa fa-'+  selectedIcon.className;
         },
-
         edit() {
             this.editor = !this.editor ;
             if ( this.entry !== null ) {
@@ -218,8 +216,6 @@ export default {
                         console.log(error);
                     });
             }
-            this.form.title = '';
-            this.form.description = '';
             this.editor = false;
 
         },

--- a/resources/js/components/plan/PlanEntry.vue
+++ b/resources/js/components/plan/PlanEntry.vue
@@ -25,7 +25,7 @@
                                    @click="destroy(entry)"></i>
                             </div>
                         </div>
-                        <div class="card-body py-2 collapse show">
+                        <div class="card-body py-2 collapse">
                             <img v-if="Number.isInteger(entry.medium_id)"
                                  class="pull-right"
                                  :src="'/media/' + entry.medium_id + '/thumb'"/>

--- a/resources/js/components/plan/PlanEntry.vue
+++ b/resources/js/components/plan/PlanEntry.vue
@@ -41,13 +41,15 @@
                         <Trainings
                             :plan="plan"
                             subscribable_type="App\PlanEntry"
-                            :subscribable_id="entry.id"></Trainings>
+                            :subscribable_id="entry.id"
+                        ></Trainings>
                     </div>
                 </div>
                 <div v-if="editor"
                      class="card-body">
                     <color-picker-input
-                        v-model="form.color"></color-picker-input>
+                        v-model="form.color"
+                    ></color-picker-input>
 
                     <div class="form-group">
                         <input

--- a/resources/js/components/training/Training.vue
+++ b/resources/js/components/training/Training.vue
@@ -44,7 +44,8 @@ export default {
         }
     },
     mounted() {
-        this.postDate();
+        // TODO: improve this
+        if (this.training.begin != null && this.training.end != null) this.postDate();
     },
     methods: {
         postDate() {

--- a/resources/lang/de/global.php
+++ b/resources/lang/de/global.php
@@ -103,6 +103,7 @@ return [
     'lastYear' => 'Letztes Jahr',
     'currentPeriod' => 'Aktueller Lernzeitraum',
     'selectDateRange' => 'Zeitraum auswählen',
+    'invalid_form' => 'Bitte füllen Sie dieses Feld aus.',
     'dashboard' => [
         'title' => 'Dashboard',
         'actual' => 'Aktuell',

--- a/resources/lang/en/global.php
+++ b/resources/lang/en/global.php
@@ -101,6 +101,7 @@ return [
     'lastYear' => 'last year',
     'currentPeriod' => 'current learning period',
     'selectDateRange' => 'Select range',
+    'invalid_form' => 'Please fill out this field.',
     'dashboard' => [
         'title' => 'Dashboard',
         'actual' => 'Aktuell',

--- a/resources/views/plans/showType4.blade.php
+++ b/resources/views/plans/showType4.blade.php
@@ -15,8 +15,8 @@
         @can('plan_edit')
             @if($plan->owner_id == auth()->user()->id)
             <div class="card-tools pr-2 no-print">
-                <a onclick="window.print();" class="link-muted pr-4">
-                    <i class="fa fa-print text-muted"></i>
+                <a onclick="window.print();" class="link-muted pr-4 pointer">
+                    <i class="fa fa-print"></i>
                 </a>
                  <a href="{{route('plans.edit', $plan->id) }}" class="link-muted">
                     <i class="fa fa-pencil-alt"></i>

--- a/routes/web.php
+++ b/routes/web.php
@@ -239,6 +239,7 @@ Route::group(['middleware' => 'auth'], function () {
 
     Route::delete('plans/massDestroy', 'PlanController@massDestroy')->name('plans.massDestroy');
     Route::get('plans/list', 'PlanController@list');
+    Route::put('plans/{plan}/syncEntriesOrder', 'PlanController@syncEntriesOrder')->name('plans.syncEntriesOrder');
     Route::resource('plans', 'PlanController');
 
     Route::resource('planSubscriptions', 'PlanSubscriptionController');


### PR DESCRIPTION
plans:
- planEntries can now be opened/closed accordion-style (default closed)
- planEntries order can now be changed per drag&drop
- enablingObjectives from same parent are now combined into a single entry
- subscribeObjectiveModal now has multi-select functionality
- subscribeObjectiveModal fixed bug where objectives weren't loaded correctly
- subscribeObjectiveModal added logic for disabling fields, when they are empty

WIP:
- firing an event to add new subscriptions to planEntry, instead of reloading the page (TODO)

fixes:
- planEntry color-picker now has a noticeable default color
- error in exercises, where inputs weren't validated
- bug where only first planEntry could be edited
- delete-icon didn't have hover event