### PR TITLE
improvements in plans | fixes

### DIFF
--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -89,7 +89,7 @@ class PlanController extends Controller
         abort_unless(\Gate::allows('plan_create'), 403);
 
         $plan = new Plan();
-        //$types = PlanType::all()
+        //$types = PlanType::all();
         $types = PlanType::whereIn('id',
                 explode(
                     ',',
@@ -208,10 +208,8 @@ class PlanController extends Controller
     {
         abort_unless((\Gate::allows('plan_delete') and $plan->isAccessible()), 403);
 
-        $plan->subscriptions()->delete();
+        $plan->entries()->delete();
         $plan->delete();
-
-        return back();
     }
 
     public function syncEntriesOrder(Plan $plan)

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -206,7 +206,7 @@ Vue.component('videoconferences', () => import('./components/videoconference/Vid
 
 Vue.component('tests-table', () => import('./components/tests/TestsTable.vue'));
 
-Vue.prototype.$initTinyMCE = function (tinyMcePlugins) {
+Vue.prototype.$initTinyMCE = function (tinyMcePlugins, attr = null) {
 
     const defaultPlugins = [
         "advlist autolink lists link image charmap print preview hr anchor pagebreak",
@@ -217,6 +217,10 @@ Vue.prototype.$initTinyMCE = function (tinyMcePlugins) {
 
     tinymce.remove();
     tinymce.init({
+        // allows adding additional attributes for specific cases
+        // attributes can be overwritten if they are set BEFORE this line
+        ...attr,
+
         path_absolute : "/",
         selector: "textarea.my-editor",
         branding:false,

--- a/resources/js/components/content/ContentCreateModal.vue
+++ b/resources/js/components/content/ContentCreateModal.vue
@@ -126,10 +126,11 @@
                     this.load(event.params.id);
                 }
             },
-            opened(){
+            opened() {
                 this.$initTinyMCE([
                         "autolink link example table lists"
-                    ]
+                    ],
+                    { height: 300 }
                 );
             },
             beforeClose() {
@@ -143,7 +144,7 @@
                     //console.log('loading failed')
                 }
             },
-            close(){
+            close() {
                 this.$modal.hide('content-create-modal');
             }
         },

--- a/resources/js/components/content/Contents.vue
+++ b/resources/js/components/content/Contents.vue
@@ -49,7 +49,6 @@
                 v-if="subscriptions.length !== 0"
                 type="button" class="btn btn-tool "
                 :href="'#contentCarousel_'+uid" role="button"
-                data-slide="prev"
                 :aria-label="trans('pagination.previous')"
                 @click="prev()">
                 <i class="fa fa-arrow-left"></i>
@@ -58,7 +57,6 @@
                 v-if="subscriptions.length !== 0"
                 type="button" class="btn btn-tool "
                 :href="'#contentCarousel_'+uid" role="button"
-                data-slide="next"
                 :aria-label="trans('pagination.next')"
                 @click="next()">
                 <i class="fa fa-arrow-right"></i>
@@ -72,7 +70,8 @@
                 <li :data-target="'#contentCarousel_'+uid"
                     data-slide-to="0"
                     class="active"
-                    @click="setSlide(0)"></li>
+                    @click="setSlide(0)">
+                </li>
                 <li v-for="(item,index) in subscriptions"
                     data-placement="top"
                     :title="item.content.title"
@@ -139,7 +138,8 @@
                 <div v-for="item in subscriptions"
                      class="carousel-item" :title="item.content.title">
                     <div class="p-3"
-                         v-html="item.content.content"></div>
+                         v-html="item.content.content"
+                    ></div>
                 </div>
             </div>
         </div>
@@ -171,24 +171,26 @@
             }
         },
         methods: {
-            setSlide(id){
+            setSlide(id) {
                 this.currentSlide = id;
             },
-            prev(){
+            prev() {
                 if (this.currentSlide === 0){
                     this.currentSlide = this.subscriptions.length;
                 } else {
                     this.currentSlide--;
                 }
+                $('#contentCarousel_' + this.uid).carousel(this.currentSlide);
             },
-            next(){
+            next() {
                 if (this.currentSlide === this.subscriptions.length){
                     this.currentSlide = 0;
                 } else {
                     this.currentSlide++;
                 }
+                $('#contentCarousel_' + this.uid).carousel(this.currentSlide);
             },
-            show(modal){
+            show(modal) {
                 this.$modal.show(modal, {
                     'referenceable_type': this.subscribable_type,
                     'referenceable_id': this.subscribable_id,
@@ -221,7 +223,7 @@
                     this.errors = error.response.data.errors;
                 }
             },
-            edit(contentSubscription){
+            edit(contentSubscription) {
                 this.$modal.show('content-create-modal', {
                     'id': contentSubscription.content_id,
                     'method': 'patch',
@@ -229,7 +231,7 @@
                     'referenceable_id': contentSubscription.subscribable_id
                 });
             },
-            async deleteSubscription(contentSubscription){
+            async deleteSubscription(contentSubscription) {
                 try {
                     await axios.post('/contents/'+contentSubscription.content_id+'/destroy',  { 'referenceable_type': contentSubscription.subscribable_type, 'referenceable_id': contentSubscription.subscribable_id } );
                     // remove on page
@@ -240,7 +242,7 @@
                     this.errors = error.response.data.errors;
                 }
             },
-            loaderEvent(){
+            loaderEvent() {
                 axios.get('/contentSubscriptions?subscribable_type='+this.subscribable_type + '&subscribable_id='+this.subscribable_id)
                     .then(response => {
                         this.subscriptions = response.data.message;

--- a/resources/js/components/curriculum/CurriculumView.vue
+++ b/resources/js/components/curriculum/CurriculumView.vue
@@ -165,7 +165,8 @@
                 <contents
                     ref="Contents"
                     subscribable_type="App\Curriculum"
-                    :subscribable_id="curriculum.id"></contents>
+                    :subscribable_id="curriculum.id">
+                </contents>
             </div>
             <div class="tab-pane fade "
                  id="medium-tab"

--- a/resources/js/components/objectives/Objectives.vue
+++ b/resources/js/components/objectives/Objectives.vue
@@ -210,6 +210,9 @@ const EnablingObjectives =
         },
         mounted() {
             this.loaderEvent();
+            this.$eventHub.$on('subscriptions_added', id => {
+                if (id === this.referenceable_id) this.loaderEvent();
+            });
         },
         components: {
             ObjectiveBox,

--- a/resources/js/components/objectives/SubscribeObjectiveModal.vue
+++ b/resources/js/components/objectives/SubscribeObjectiveModal.vue
@@ -150,7 +150,7 @@
                     if (this.requestUrl == '/terminalObjectiveSubscriptions') {
                         this.terminal_objective_id.forEach(async id => {
 
-                            this.location = (await axios.post(this.requestUrl, {
+                            (await axios.post(this.requestUrl, {
                                 'curriculum_id':            this.curriculum_id,
                                 'terminal_objective_id':    id,
                                 'enabling_objective_id':    this.enabling_objective_id,
@@ -162,7 +162,7 @@
                     } else {
                         this.enabling_objective_id.forEach(async id => {
 
-                            this.location = (await axios.post(this.requestUrl, {
+                            (await axios.post(this.requestUrl, {
                                 'curriculum_id':            this.curriculum_id,
                                 'terminal_objective_id':    this.terminal_objective_id,
                                 'enabling_objective_id':    id,
@@ -172,8 +172,9 @@
 
                         });
                     }
-                    location.reload(true);
 
+                    this.$eventHub.$emit('subscriptions_added', this.referenceable_id);
+                    this.close();
                 } catch(error) {
                     //
                 }
@@ -187,6 +188,12 @@
             beforeClose() {},
             opened() {
                 this.initSelect2();
+            },
+            close() {
+                this.$modal.hide('subscribe-objective-modal');
+                // if the user re-opens the modal, only save which 'curriculum' was picked
+                this.enabling_objective_id = [];
+                this.terminal_objective_id = [];
             },
             initSelect2() {
                 $("#curricula").select2({
@@ -239,9 +246,6 @@
                 .on('select2:unselect', function (e) {
                     this.enabling_objective_id.splice(this.enabling_objective_id.findIndex(id => id == e.params.data.id), 1);
                 }.bind(this));
-            },
-            close() {
-                this.$modal.hide('subscribe-objective-modal');
             },
             removeHtmlTags(array, field) {
                 for (let i = 0; i < array.length; i++) {

--- a/resources/js/components/plan/Plan.vue
+++ b/resources/js/components/plan/Plan.vue
@@ -12,7 +12,8 @@
                 @end="handleEntryOrder"
             >
                 <PlanEntry
-                    v-for="entry in entries"
+                    v-for="(entry, index) in entries"
+                    :key="entries[index].id"
                     :entry="entry"
                     :plan="plan"
                 ></PlanEntry>

--- a/resources/js/components/plan/Plan.vue
+++ b/resources/js/components/plan/Plan.vue
@@ -111,13 +111,13 @@ export default {
         this.loaderEvent();
         this.entries = this.plan.entries;
         this.$eventHub.$on('plan_entry_added', (e) => {
-            this.handleEntryAdded();
+            this.handleEntryAdded(e);
         });
         this.$eventHub.$on('plan_entry_updated', (e) => {
             this.loaderEvent();
         });
         this.$eventHub.$on('plan_entry_deleted', (e) => {
-            this.handleEntryDeleted();
+            this.handleEntryDeleted(e);
         });
         this.$eventHub.$on('objective_added', (objective, entryId) => {
             this.handleObjectiveAdded(objective, entryId);

--- a/resources/js/components/plan/Plan.vue
+++ b/resources/js/components/plan/Plan.vue
@@ -6,14 +6,14 @@
             <!-- Bewegungsfeld -->
             <draggable
                 v-can="'plan_edit'"
-                v-model="entry_order"
+                v-bind="columnDragOptions"
+                v-model="entries"
                 @start="drag=true"
                 @end="handleEntryOrder"
             >
                 <PlanEntry
-                    v-for="(value, index) in entry_order"
-                    v-bind:key="entries[index].id"
-                    :entry="entries[index]"
+                    v-for="entry in entries"
+                    :entry="entry"
                     :plan="plan"
                 ></PlanEntry>
             </draggable>
@@ -62,12 +62,13 @@ export default {
                 .then(response => {
                     if (this.plan.entry_order != null) {
                         this.entry_order = this.plan.entry_order
+                        // rearrange entries to the specified order by their ID
+                        // since this is O[n^2], it could become a performance issue in the future
                         this.entries = this.entry_order.map(
-                            order_id => response.data.entries.find(entry => entry.id === order_id)
+                            id => response.data.entries.find(entry => entry.id === id)
                         );
                     } else {
                         this.entries = response.data.entries;
-                        this.entry_order = this.entries.map(entry => entry.id);
                     }
                 })
                 .catch(e => {
@@ -77,7 +78,7 @@ export default {
         handleEntryAdded(entry) {
             this.entries.push(entry);
             this.entry_order.push(entry.id);
-            this.handleEntryOrder();
+            this.updateEntryOrder();
         },
         handleEntryDeleted(entry){
             let index = this.entries.indexOf(entry);
@@ -85,16 +86,9 @@ export default {
             this.entry_order.splice(index, 1);
             this.updateEntryOrder();
         },
-        //? maybe put event in Objectives.vue
-        handleObjectiveAdded(objective, entryId) {
-            const entry = this.entries.find(entry => entry.id === entryId);
-        },
-        handleEntryOrder() {
-            // rearrange entries to the specified order by ID
-            // since this is O[n^2], it could be a performance problem in the future
-            this.entries = this.entry_order.map(
-                order_id => this.entries.find(entry => entry.id === order_id)
-            );
+        handleEntryOrder(e) {
+            if (e.newIndex === e.oldIndex) return;
+            this.entry_order = this.entries.map(entry => entry.id);
             this.updateEntryOrder();
         },
         updateEntryOrder() {
@@ -119,9 +113,15 @@ export default {
         this.$eventHub.$on('plan_entry_deleted', (e) => {
             this.handleEntryDeleted(e);
         });
-        this.$eventHub.$on('objective_added', (objective, entryId) => {
-            this.handleObjectiveAdded(objective, entryId);
-        });
+    },
+    computed: {
+        columnDragOptions() {
+            return {
+                animation: 200,
+                // checks if a mobile-browser is used and if true, add delay
+                ...(/Mobi/i.test(window.navigator.userAgent) && {delay: 200}),
+            };
+        },
     },
     components: {
         Calendar,

--- a/resources/js/components/plan/PlanEntry.vue
+++ b/resources/js/components/plan/PlanEntry.vue
@@ -66,13 +66,13 @@
                     </div>
 
                     <div class="form-group">
-                            <textarea
-                                id="description"
-                                name="description"
-                                :placeholder="trans('global.planEntry.fields.description')"
-                                class="form-control description my-editor"
-                                v-model.trim="form.description"
-                            ></textarea>
+                        <textarea
+                            id="description"
+                            name="description"
+                            :placeholder="trans('global.planEntry.fields.description')"
+                            class="form-control description my-editor"
+                            v-model.trim="form.description"
+                        ></textarea>
                         <p class="help-block" v-if="form.errors.description" v-text="form.errors.description[0]"></p>
                     </div>
                     <div class="form-group">

--- a/resources/js/components/training/Trainings.vue
+++ b/resources/js/components/training/Trainings.vue
@@ -16,19 +16,18 @@
                         <small class="badge badge-secondary mr-2 ">
                             {{ diffForHumans(training.begin) }} - {{ diffForHumans(training.end) }}
                         </small>
-                        <span v-if="$userId == plan.owner_id">
+                        <span v-if="$userId == plan.owner_id" class="icons">
                             <a @click="lower(training)" >
-                                <i class="pr-2 fa fa-caret-up text-muted"></i>
+                                <i class="px-1 fa fa-caret-up text-muted"></i>
                             </a>
                             <a @click="higher(training)" >
-                                <i class="pr-2 fa fa-caret-down text-muted"></i>
+                                <i class="px-1 fa fa-caret-down text-muted"></i>
                             </a>
                             <a @click="edit(training)" >
-                                <i class="pr-2 fa fa-pencil-alt text-muted"></i>
+                                <i class="px-1 fa fa-pencil-alt text-muted"></i>
                             </a>
-
                             <a @click="destroy(training)" >
-                                <i class="fas fa-trash text-danger"></i>
+                                <i class="px-1 fas fa-trash text-danger"></i>
                             </a>
                         </span>
 
@@ -188,7 +187,7 @@ export default {
         },
         higher(training){
             this.form.id = training.id;
-            this.form.order_id = this.form.order_id + 1 ;
+            this.form.order_id = this.form.order_id + 1;
             this.method = 'patch';
             this.submit(training);
         },
@@ -220,9 +219,13 @@ export default {
             this.editor = false;
         },
         diffForHumans: function (date) {
-            return  moment(date).locale('de').fromNow();
+            return moment(date).locale('de').fromNow();
         },
     },
 
 }
 </script>
+<style scoped>
+.icons:hover { cursor: default; }
+.icons i:hover { cursor: pointer; }
+</style>

--- a/resources/js/components/training/Trainings.vue
+++ b/resources/js/components/training/Trainings.vue
@@ -11,11 +11,18 @@
                     <a :href="'/trainings/'+training.id">{{training.title}}</a>
 
                     <!-- General tools such as edit or delete-->
-                    <div
-                         class="tools pull-right ">
-                        <small class="badge badge-secondary mr-2 ">
-                            {{ diffForHumans(training.begin) }} - {{ diffForHumans(training.end) }}
-                        </small>
+                    <div class="tools pull-right">
+                        <span>
+                            <small v-if="training.begin !== null && training.end !== null" class="badge badge-secondary mr-2">
+                                {{ diffForHumans(training.begin) }} - {{ diffForHumans(training.end) }}
+                            </small>
+                            <small v-else-if="training.begin !== null" class="badge badge-secondary mr-2">
+                                {{ trans('global.begin') + ' ' + diffForHumans(training.begin) }}
+                            </small>
+                            <small v-else-if="training.end !== null" class="badge badge-secondary mr-2">
+                                {{ trans('global.end') + ' ' + diffForHumans(training.end) }}
+                            </small>
+                        </span>
                         <span v-if="$userId == plan.owner_id" class="icons">
                             <a @click="lower(training)" >
                                 <i class="px-1 fa fa-caret-up text-muted"></i>

--- a/resources/lang/de/auth.php
+++ b/resources/lang/de/auth.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'or' => 'ODER',
     'failed' => 'Diese Anmeldedaten stimmen nicht mit den hinterlegten Daten überein.',
     'throttle' => 'Zu viele Anmeldeversuche. Bitte versuchen Sie es erneut in :seconds Sekunden.',
     'site_title' => 'curriculum',

--- a/resources/lang/en/auth.php
+++ b/resources/lang/en/auth.php
@@ -1,6 +1,7 @@
 <?php
 
 return [
+    'or' => 'OR',
     'failed' => 'These credentials do not match our records.',
     'throttle' => 'Too many login attempts. Please try again in :seconds seconds.',
     'site_title' => 'curriculum',

--- a/resources/sass/rlp/_table.scss
+++ b/resources/sass/rlp/_table.scss
@@ -31,13 +31,6 @@
     padding: 0 .5rem !important;
 }
 
-.table td:last-child a:last-child,
-.table th:last-child a:last-child,
-.table td:last-child button:last-child,
-.table th:last-child button:last-child {
- padding: 0 0 0 .5rem !important;
-}
-
 .table thead {
     font-weight: 400;
     font-size: 14px;

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -75,18 +75,19 @@
             </form>
             @if ( ( env('SAML2_RLP_IDP_SSO_URL') !== null ) AND ( !empty(env('SAML2_RLP_IDP_SSO_URL')) ) )
                 <div class="social-auth-links text-center mb-3">
-                    <p>- OR -</p>
+                    <p>- {{ trans('auth.or') }} -</p>
                     <a href="{{ route('saml2_login', ['idpName' => config('saml2_settings.idpNames')[0]]) }}" class="btn btn-block btn-primary">
                         <i class=" mr-2"></i> {{ trans('global.login_SSO') }}
                     </a>
                 </div>
             @endif
-
-            <p class="mb-1">
-                <a class="" href="{{ route('password.request') }}">
-                    {{ trans('global.forgot_password') }}
-                </a>
-            </p>
+            @if (env('ALLOW_PASSWORD_RESET') === true)
+                <p class="mb-1">
+                    <a class="" href="{{ route('password.request') }}">
+                        {{ trans('global.forgot_password') }}
+                    </a>
+                </p>
+            @endif
             <p class="mb-0">
                 @if ( ( env('SHOW_IMRESSUM') !== null ))
                     <a class="" href="{{ route('impressum') }}">

--- a/resources/views/layouts/master.blade.php
+++ b/resources/views/layouts/master.blade.php
@@ -101,7 +101,7 @@
             serverSide: true,
             language: {
                 url: languages.{{ app() -> getLocale() }},
-                searchPlaceholder: '{{ trans('global.search') }}',
+                searchPlaceholder: "{{ trans('global.search') }}",
                 paginate: {
                             "first":      '<i class="fa fa-angle-double-left"></id>',
                             "last":       '<i class="fa fa-angle-double-right"></id>',
@@ -162,11 +162,11 @@
                }
 
                function destroyDataTableEntry(route, id){
-                    if (confirm('{{ trans('global.areYouSure') }}')) {
+                    if (confirm("{{ trans('global.areYouSure') }}")) {
                         $.ajax({
-                            headers: {'x-csrf-token': _token},
+                            headers: { 'x-csrf-token': _token },
                             method: 'POST',
-                            url: route+'/'+id,
+                            url: '/'+route+'/'+id,
                             data: { _method: 'DELETE' }
                         })
                         .done(function () {

--- a/resources/views/plans/index.blade.php
+++ b/resources/views/plans/index.blade.php
@@ -40,12 +40,12 @@ $(document).ready( function () {
     var table = $('#plans-datatable').DataTable({
         ajax: "{{ url('plans/list') }}",
         columns: [
-                 { data: 'check'},
-                 { data: 'title' },
-            {data: 'action'}
+            { data: 'check' },
+            { data: 'title' },
+            { data: 'action' }
         ],
         columnDefs: [
-            {"visible": false, "targets": 0},
+            { "visible": false, "targets": 0 },
             {
                 orderable: false,
                 searchable: false,
@@ -62,7 +62,9 @@ $(document).ready( function () {
         },
         buttons: dtButtons
     });
-    table.on('click', 'tr', function () {
+    table.on('click', 'tr', function (e) {
+        // trying to delete an entry will run this function first
+        if (e.target.tagName == "BUTTON" || e.target.tagName == "I") return;
         window.location.href = "/plans/" + table.row(this).id()
     });
 


### PR DESCRIPTION
plans:
- fixed bug where adding or removing an entry wouldn't update the DOM
- plan-table: action-cell had missing padding, which caused incosistency for icon-width
- fixed not being able to delete plans
- adding a planEntrySubscription doesn't need a reload anymore
- drag&drop improvements (animation/hold for mobile/fixed bug for entry-order)
- trainings: added hover style for icons | logic for begin/end date when unset

fixes:
- the 'password reset' link in the login screen can now be hidden/shown per .env variable (default: hidden)
- curricula: carousel showing wrong content
- increased default tinyMCE-size in curricula-content-modal
  -> added support to add additional attributes to tinyMCE-plugin