### PR TITLE
achievements-modal in plans now working

### DIFF
--- a/app/Http/Controllers/PlanController.php
+++ b/app/Http/Controllers/PlanController.php
@@ -150,11 +150,14 @@ class PlanController extends Controller
         if ($plan->owner_id === auth()->user()->id) {
             foreach ($subscriptions as $subscription) {
                 if ($subscription['subscribable_type'] == 'App\Group') {
-                    $group_users = Group::find($subscription['id'])->users()->get()->toArray();
+                    $group_users = Group::find($subscription['subscribable_id'])->users()->get()->toArray();
                     $users = array_merge($users, $group_users);
-                } else {
-                    $user = User::find($subscription['id'])->toArray();
+                } else if ($subscription['subscribable_type'] == 'App\User') {
+                    $user = User::find($subscription['subscribable_id'])->toArray();
                     array_push($users, $user);
+                } else if ($subscription['subscribable_type'] == 'App\Organization') {
+                    $organization_users = Organization::find($subscription['subscribable_id'])->users()->get()->toArray();
+                    $users = array_merge($users, $organization_users);
                 }
             }
         }

--- a/app/Plan.php
+++ b/app/Plan.php
@@ -86,6 +86,7 @@ class Plan extends Model
         if (
             auth()->user()->plans->contains('id', $this->id) // user enrolled
             or ($this->subscriptions->where('subscribable_type', "App\Group")->whereIn('subscribable_id', auth()->user()->groups->pluck('id')))->isNotEmpty() //user is enroled in group
+            or ($this->subscriptions->where('subscribable_type', "App\Organization")->whereIn('subscribable_id', auth()->user()->current_organization_id))->isNotEmpty() //user is enroled in organization
             or ($this->owner_id == auth()->user()->id)            // or owner
             or is_admin() // or admin
         ) {

--- a/resources/js/components/objectives/SubscribeObjectiveModal.vue
+++ b/resources/js/components/objectives/SubscribeObjectiveModal.vue
@@ -3,6 +3,8 @@
         id="subscribe-objective-modal"
         name="subscribe-objective-modal"
         height="420px"
+        :minWidth="300"
+        :minHeight="420"
         :adaptive=true
         draggable=".draggable"
         :resizable=true

--- a/resources/js/components/plan/SetAchievementsModal.vue
+++ b/resources/js/components/plan/SetAchievementsModal.vue
@@ -54,7 +54,7 @@
                             <td>
                                 <AchievementIndicator
                                     v-permission="'achievement_create'"
-                                    :objective="objective"
+                                    :objective="objective[user.id] ?? objective.default"
                                     :type="'enabling'"
                                     :users="[user.id]"
                                     :settings="{'achievements' : false, 'edit': false}">
@@ -85,18 +85,35 @@ export default {
             objective: {},
         };
     },
-    mounted() {
-        
-    },
+    mounted() {},
     methods: {
         close() {
             this.$modal.hide('set-achievements-modal');
+            this.objective = {};
         },
         submit() {
             this.close();
         },
+        /**
+         * since we need the achievement-status combined with the specific user,
+         * we'll create an object with the user_id as the attribute
+         * and set a default for users with no achievement
+         * INFO: I don't want to do a double for-loop because O(n^2)
+         */
         beforeOpen(event) {
-            this.objective = event.params.objective;
+            const eventObj = event.params.objective;
+            const obj = {}; // if we add attributes directly to 'this.objective' it won't work
+            obj.default = { id: eventObj.id };
+            
+            eventObj.achievements.forEach(achievement => {
+                // only add attributes that are actually needed
+                obj[achievement.user_id] = {
+                    id: eventObj.id,
+                    achievements: [achievement],
+                };
+            });
+
+            this.objective = obj;
         },
         beforeClose() {},
         opened() {},

--- a/resources/js/components/plan/SetAchievementsModal.vue
+++ b/resources/js/components/plan/SetAchievementsModal.vue
@@ -3,6 +3,8 @@
         id="set-achievements-modal"
         name="set-achievements-modal"
         height="60%"
+        :minWidth="300"
+        :minHeight="420"
         :adaptive=true
         draggable=".draggable"
         :resizable=true


### PR DESCRIPTION
- plans can now be shared with organizations
- fixed bug in getting the plan-subscription users for achievements
- when opening the set-achievements-modal, the previous set achievements now get correctly displayed
- fixed being able to resize modals to 0px (basically making them unusable until reload)