### PR TITLE
Fixes

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -41,7 +41,8 @@ class GroupsController extends Controller
         switch (auth()->user()->role()->id) {
             case 1:  $groups = Group::with(['grade', 'period', 'organization']);
                 break;
-            case 4:  $groups = Group::where('organization_id', auth()->user()->current_organization_id)->with(['grade', 'period', 'organization']);
+            case 4: // Schooladmins and Teachers should only see groups of current organization
+            case 5:  $groups = Group::where('organization_id', auth()->user()->current_organization_id)->with(['grade', 'period', 'organization']);
                 break;
 
             default: $groups = auth()->user()->groups()->with(['grade', 'period', 'organization']);

--- a/app/Http/Controllers/KanbanSubscriptionController.php
+++ b/app/Http/Controllers/KanbanSubscriptionController.php
@@ -22,7 +22,7 @@ class KanbanSubscriptionController extends Controller
         if (isset($input['subscribable_type']) and isset($input['subscribable_id'])) {
             //used by grous.view
             $model = $input['subscribable_type']::find($input['subscribable_id']);
-            abort_unless((\Gate::allows('kanban_access') and $model->isAccessible()), 403);
+            abort_unless((\Gate::allows('kanban_access') and $model->isAccessible() or is_admin()), 403);
             $kanbans = $model->kanbans;
 
             return empty($kanbans) ? '' : DataTables::of($kanbans)

--- a/app/Http/Controllers/LogbookSubscriptionController.php
+++ b/app/Http/Controllers/LogbookSubscriptionController.php
@@ -19,7 +19,7 @@ class LogbookSubscriptionController extends Controller
 
         if (isset($input['subscribable_type']) and isset($input['subscribable_id'])) {
             $model = $input['subscribable_type']::find($input['subscribable_id']);
-            abort_unless((\Gate::allows('logbook_access') and $model->isAccessible()), 403);
+            abort_unless((\Gate::allows('logbook_access') and $model->isAccessible() or is_admin()), 403);
 
             $subscriptions = LogbookSubscription::where([
                 'subscribable_type' => $input['subscribable_type'],

--- a/app/Http/Controllers/OrganizationsController.php
+++ b/app/Http/Controllers/OrganizationsController.php
@@ -61,18 +61,20 @@ class OrganizationsController extends Controller
             })
             ->addColumn('action', function ($organizations) use ($edit_gate, $delete_gate, $organization_id_field) {
                 $actions = '';
-                if ($edit_gate) {
-                    $actions .= '<a href="'.route('organizations.edit', $organizations->id).'"'
-                                    .'id="edit-organization-'.$organizations->$organization_id_field.'" '
-                                    .'class="btn p-1">'
-                                    .'<i class="fa fa-pencil-alt"></i>'
-                                    .'</a>';
-                }
-                if ($delete_gate) {
-                    $actions .= '<button type="button" '
-                                .'class="btn text-danger" '
-                                .'onclick="destroyDataTableEntry(\'organizations\','.$organizations->$organization_id_field.')">'
-                                .'<i class="fa fa-trash"></i></button>';
+                if ($organizations->role_id == 4 || is_admin()) { // only show edit/delete in orgs where the user is a schooladmin
+                    if ($edit_gate) {
+                        $actions .= '<a href="'.route('organizations.edit', $organizations->id).'"'
+                        .'id="edit-organization-'.$organizations->$organization_id_field.'" '
+                        .'class="btn p-1">'
+                        .'<i class="fa fa-pencil-alt"></i>'
+                        .'</a>';
+                    }
+                    if ($delete_gate) {
+                        $actions .= '<button type="button" '
+                        .'class="btn text-danger" '
+                        .'onclick="destroyDataTableEntry(\'organizations\','.$organizations->$organization_id_field.')">'
+                        .'<i class="fa fa-trash"></i></button>';
+                    }
                 }
 
                 return $actions;

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -228,10 +228,10 @@ Vue.prototype.$initTinyMCE = function (tinyMcePlugins, attr = null) {
 
         path_absolute : "/",
         selector: "textarea.my-editor",
-        branding:false,
+        branding: false,
         plugins: tinyMcePlugins ?? defaultPlugins,
         external_plugins: {'mathjax': '/node_modules/@dimakorotkov/tinymce-mathjax/plugin.min.js'},
-        toolbar: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | example mathjax link image media ",
+        toolbar: "insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | example mathjax link image media code",
         relative_urls: false,
         entity_encoding : "raw",
         language: 'de',

--- a/resources/js/components/content/ContentCreateModal.vue
+++ b/resources/js/components/content/ContentCreateModal.vue
@@ -128,11 +128,14 @@
                 }
             },
             opened() {
+                const plugins = "autolink link table lists" + (this.method === 'patch' ? ' example' : '');
                 this.$initTinyMCE([
-                        "autolink link example table lists"
+                        plugins
                     ],
                     {
                         height: 300,
+                        'referencable_type': this.form.referenceable_type,
+                        'referencable_id': this.form.referenceable_id,
                         'eventHubCallbackFunction': 'insertContent',
                         'eventHubCallbackFunctionParams': this.component_id,
                     }

--- a/resources/js/components/content/ContentCreateModal.vue
+++ b/resources/js/components/content/ContentCreateModal.vue
@@ -134,8 +134,8 @@
                     ],
                     {
                         height: 300,
-                        'referencable_type': this.form.referenceable_type,
-                        'referencable_id': this.form.referenceable_id,
+                        'referenceable_type': this.form.referenceable_type,
+                        'referenceable_id': this.form.referenceable_id,
                         'eventHubCallbackFunction': 'insertContent',
                         'eventHubCallbackFunctionParams': this.component_id,
                     }

--- a/resources/js/components/content/ContentCreateModal.vue
+++ b/resources/js/components/content/ContentCreateModal.vue
@@ -128,7 +128,7 @@
                 }
             },
             opened() {
-                const plugins = "autolink link table lists" + (this.method === 'patch' ? ' example' : '');
+                const plugins = "autolink link table lists code" + (this.method === 'patch' ? ' example' : '');
                 this.$initTinyMCE([
                         plugins
                     ],

--- a/resources/js/components/content/Contents.vue
+++ b/resources/js/components/content/Contents.vue
@@ -240,8 +240,8 @@ export default {
             this.$modal.show('content-create-modal', {
                 'id': contentSubscription.content_id,
                 'method': 'patch',
-                'referenceable_type': contentSubscription.subscribable_type,
-                'referenceable_id': contentSubscription.subscribable_id
+                'referenceable_type': 'App\\Content',
+                'referenceable_id': contentSubscription.content_id,
             });
         },
         async deleteSubscription(contentSubscription) {

--- a/resources/js/components/kanban/KanbanBoard.vue
+++ b/resources/js/components/kanban/KanbanBoard.vue
@@ -653,12 +653,12 @@ export default {
 }
 .content-only .kanban_board_container { width: calc(100vw - 1rem); }
 .kanban_board_wrapper {
-    position:absolute;
+    position: absolute;
     height: 100%;
     width: 100%;
     padding: 2rem;
-    overflow-y:clip;
-    overflow-x: scroll;
+    overflow-y: clip;
+    overflow-x: overlay;
 }
 @media (max-width: 991px) {
     .kanban_board_container { width: calc(100vw - 30px) !important; }

--- a/resources/js/components/kanban/KanbanIndexWidget.vue
+++ b/resources/js/components/kanban/KanbanIndexWidget.vue
@@ -12,9 +12,9 @@
                 class="nav-item-box-image-size"
             >
                 <render-usage
-                    class="d-flex align-items-center nav-item-box-image-size user-select-none"
+                    class="d-flex align-items-center user-select-none"
                     :medium="{ id: kanban.medium_id }"
-                    :style="{ backgroundColor: kanban.color + ' !important' }"
+                    :style="{ backgroundColor: kanban.color + ' !important', minHeight: '150px', borderTopLeftRadius: '.2rem' }"
                     :enableClick="false"
                 ></render-usage>
             </div>

--- a/resources/js/components/kanban/KanbanItem.vue
+++ b/resources/js/components/kanban/KanbanItem.vue
@@ -381,7 +381,7 @@ export default {
             this.$nextTick(() => {
                 this.$initTinyMCE(
                     [
-                        "autolink link"
+                        "autolink link code"
                     ]
                 );
             });

--- a/resources/js/components/kanban/KanbanItemCreate.vue
+++ b/resources/js/components/kanban/KanbanItemCreate.vue
@@ -187,7 +187,7 @@ export default {
         }
         this.$initTinyMCE(
             [
-                "autolink link"
+                "autolink link code"
             ]
         );
     },

--- a/resources/js/components/logbooks/LogbookCreate.vue
+++ b/resources/js/components/logbooks/LogbookCreate.vue
@@ -70,8 +70,8 @@
                                     :form="form"
                                     :id="component_id"
                                     :medium_id="form.medium_id"
-                                    :referencable_type="'App\\Logbook'"
-                                    :referencable_id="form.id"
+                                    :referenceable_type="'App\\Logbook'"
+                                    :referenceable_id="form.id"
                                     accept="image/*"
                                 />
                                 <div class="dropdown">

--- a/resources/js/components/logbooks/LogbookEntry.vue
+++ b/resources/js/components/logbooks/LogbookEntry.vue
@@ -204,8 +204,9 @@
                          v-bind:id="'logbook_media_'+entry.id">
                         <media subscribable_type="App\LogbookEntry"
                                :subscribable_id="entry.id"
-                               format="list">
-                        </media>
+                               format="list"
+                               :can_add_media="$userId == logbook.owner_id"
+                        ></media>
                     </div>
                     <!-- /.tab-pane -->
                     <div class="tab-pane"

--- a/resources/js/components/logbooks/LogbookEntryModal.vue
+++ b/resources/js/components/logbooks/LogbookEntryModal.vue
@@ -156,7 +156,7 @@ export default {
         },
         opened() {
             this.$initTinyMCE([
-                "autolink link example"
+                "autolink link example code"
             ], {
                 'public': 1,
                 'referenceable_type': 'App\\\Logbook',

--- a/resources/js/components/objectives/ObjectiveView.vue
+++ b/resources/js/components/objectives/ObjectiveView.vue
@@ -8,7 +8,7 @@
                     <span v-if="type === 'enabling'">{{ trans('global.enablingObjective.title_singular') }}</span>
                     <span v-else> {{ trans('global.terminalObjective.title_singular') }}</span>
 
-                    <div v-can="'task_edit'" class="card-tools">
+                    <div v-if="objective.curriculum.owner_id == $userId" v-can="'task_edit'" class="card-tools">
                         <a @click.prevent="editObjective()" class="px-1" role="button">
                             <i class="fa fa-pencil-alt text-secondary"></i>
                         </a>

--- a/resources/js/components/objectives/ObjectiveView.vue
+++ b/resources/js/components/objectives/ObjectiveView.vue
@@ -8,9 +8,9 @@
                     <span v-if="type === 'enabling'">{{ trans('global.enablingObjective.title_singular') }}</span>
                     <span v-else> {{ trans('global.terminalObjective.title_singular') }}</span>
 
-                    <div v-can="'task_edit'" class="card-tools pr-2">
-                        <a @click.prevent="editObjective()">
-                            <i class="fa fa-pencil-alt"></i>
+                    <div v-can="'task_edit'" class="card-tools">
+                        <a @click.prevent="editObjective()" class="px-1" role="button">
+                            <i class="fa fa-pencil-alt text-secondary"></i>
                         </a>
                     </div>
                 </div>

--- a/resources/js/components/plan/PlanEntry.vue
+++ b/resources/js/components/plan/PlanEntry.vue
@@ -87,8 +87,8 @@
                         <MediumForm :form="form"
                                     :id="component_id"
                                     :medium_id="form.medium_id"
-                                    :referencable_type="'App\\PlanEntry'"
-                                    :referencable_id="form.id"
+                                    :referenceable_type="'App\\PlanEntry'"
+                                    :referenceable_id="form.id"
                                     accept="image/*"/>
                     </div>
                     <button :name="'planEntrySave'"

--- a/resources/views/kanbans/show.blade.php
+++ b/resources/views/kanbans/show.blade.php
@@ -11,14 +11,14 @@
         @endcan
     @endif--}}
     <small>{{ $kanban->title }} </small>
-    @if(Auth::user()->id == $kanban->owner_id)
+    @if(Auth::user()->id == $kanban->owner_id or is_admin())
         <a class="btn btn-flat"
            onclick="app.__vue__.$eventHub.$emit('edit_kanban', {{$kanban->toJson()}})"
            >
             <i class="fa fa-pencil-alt text-secondary"></i>
         </a>
         @can('kanban_create')
-            @if(!$is_shared)
+            @if(!$is_shared or is_admin())
                 <button class="btn btn-flat"
                         onclick="app.__vue__.$modal.show('subscribe-modal',  {'modelId': {{ $kanban->id }}, 'modelUrl': 'kanban','shareWithToken': true });">
                     <i class="fa fa-share-alt text-secondary"></i>

--- a/resources/views/logbooks/show.blade.php
+++ b/resources/views/logbooks/show.blade.php
@@ -3,7 +3,7 @@
 @section('title')
     <small>{{ $logbook->title }}</small>
     @can('logbook_create')
-        @if (Auth::user()->id ==  $logbook->owner_id)
+        @if (Auth::user()->id ==  $logbook->owner_id or is_admin())
             <a class="btn btn-flat"
                 onclick="app.__vue__.$eventHub.$emit('edit_logbook', {{$logbook->toJson()}})"
             >


### PR DESCRIPTION
- fixed edit-icon behaviour in enablingObjectives/terminalObjectives
- fixed media-upload in logbook content-modal
- fixed reference_type for content-modal
- fixed LogbookEntry add-media not showing
- enabling/terminal: edit-icon now only shows if curriculum-owner
- SetAchievementsModal: sort by name as default
- fixed teachers seeing all groups of all orgs they're in
- fixed schooladmins being able to edit all listed organizations (even if they're not schooladmin in all listed organizations)
- fixed medium-upload in some components because of typo (referenCABLE => referenCEABLE)
- fixed external media height/width not scaling correctly on mobile
- admins now see subscriptions of kanbans and logbooks
- tinyMCE: added code-plugin to menu-bar and activated it in KanbanItem/LogbookEntry/Content
- fixed KanbanBoard x-axos scrollbar always being visible even if not needed