### PR TITLE
fix: Protect Curriculum import with the `curriculum_create` permission

### DIFF
--- a/app/Http/Controllers/CurriculumImportController.php
+++ b/app/Http/Controllers/CurriculumImportController.php
@@ -26,6 +26,8 @@ class CurriculumImportController extends Controller
 {
     public function import()
     {
+        abort_unless(Gate::allows('curriculum_create'), 403);
+
         return view('curricula.import');
     }
 
@@ -34,6 +36,8 @@ class CurriculumImportController extends Controller
      */
     public function store()
     {
+        abort_unless(Gate::allows('curriculum_create'), 403);
+
         ini_set('max_file_uploads', 200);
         if (! request()->hasFile('imports')) {
             return redirect('/home');


### PR DESCRIPTION
This endpoint previously allowed importing curricula, even for users who would not be able to create curricula normally.