### PR TITLE
fix: Ignore null/undefined with v-dompurify-html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
                 "datatables.net-buttons": "^2.2.3",
                 "datatables.net-dt": "^1.12.1",
                 "datatables.net-select": "^1.4.0",
+                "dompurify": "^3.1.6",
                 "form-backend-validation": "^2.4.0",
                 "laravel-echo": "^1.15.0",
                 "laravel-vue-datatable": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "datatables.net-buttons": "^2.2.3",
         "datatables.net-dt": "^1.12.1",
         "datatables.net-select": "^1.4.0",
+        "dompurify": "^3.1.6",
         "form-backend-validation": "^2.4.0",
         "laravel-echo": "^1.15.0",
         "laravel-vue-datatable": "^0.6.0",

--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -15,8 +15,27 @@ window.Vue = require('vue').default;
 window.moment = require('moment');
 
 //security
-import VueDompurifyHtml from 'vue-dompurify-html';
-Vue.use(VueDompurifyHtml);
+import { buildVueDompurifyHTMLDirective } from 'vue-dompurify-html';
+import DOMPurify from 'dompurify';
+const createWrapper = (inner) => {
+    return (el, binding) => {
+        if (binding.value === undefined || binding.value === null) {
+            return;
+        }
+        inner(el, binding);
+    };
+};
+const directive = buildVueDompurifyHTMLDirective({}, () => DOMPurify);
+Vue.directive(
+    'dompurify-html',
+    {
+        inserted: createWrapper(directive),
+        update: createWrapper(directive),
+        unbind(el) {
+            el.innerHTML = '';
+        },
+    }
+);
 
 //broadcasting
 import VueEcho from 'vue-echo';


### PR DESCRIPTION
This ignores null/undefined values when calling `v-dompurify-html`. `v-html` did this automatically, and my previous change that added `v-dompurify-html` broke this behaviour, causing a few views in the UI to display the text "null" instead of being empty as they should be.