### PR TITLE
fix: Highlight kanban missing title

### DIFF
--- a/resources/js/components/kanban/KanbanItem.vue
+++ b/resources/js/components/kanban/KanbanItem.vue
@@ -77,6 +77,8 @@
                         :id="'title_'+index"
                         type="text"
                         class="ml-2"
+                        :class="{ 'missing-input': highlightTitleInput }"
+                        @input="highlightTitleInput = false"
                         v-model="form.title"
                         style="width: 235px !important;font-size: 1.1rem; font-weight: 400; border: 0; border-bottom: 1px; border-style:solid; margin: 0;"
                         :style="{ backgroundColor: item.color, color: textColor }"
@@ -346,7 +348,8 @@ export default {
                 'visible_until': null,
             }),
             expand: false,
-            editors: {}
+            editors: {},
+            highlightTitleInput: false,
         };
     },
     computed:{
@@ -388,6 +391,13 @@ export default {
 
         },
         submit() {
+            if (this.form.title == null || this.form.title == ""){
+                const titleInput = document.getElementById('title_' + this.component_id);
+                titleInput.focus();
+                this.highlightTitleInput = true;
+                return;
+            }
+
             this.form.description = tinyMCE.get('description_'+this.item.id).getContent();
 
             axios.patch('/kanbanItems/' + this.form.id, this.form)
@@ -520,5 +530,9 @@ export default {
     font-size: 10px;
     line-height: 11px;
     vertical-align: middle;
+}
+
+.missing-input {
+    border-color: red !important;
 }
 </style>

--- a/resources/js/components/kanban/KanbanItemCreate.vue
+++ b/resources/js/components/kanban/KanbanItemCreate.vue
@@ -16,6 +16,8 @@
                 type="text"
                 v-model="form.title"
                 class="ml-2"
+                :class="{ 'missing-input': highlightTitleInput }"
+                @input="highlightTitleInput = false"
                 style="width: 235px !important;font-size: 1.1rem; font-weight: 400; border: 0; border-bottom: 1px; border-style:solid; margin: 0;"
                 :style="{ backgroundColor: form.color, color: textColor }"
             />
@@ -161,6 +163,7 @@ export default {
                 'visible_until': null,
             }),
             expand: false,
+            highlightTitleInput: false,
         };
     },
     created() {
@@ -221,6 +224,12 @@ export default {
             }
         },
         submit() {
+            if (this.form.title == null || this.form.title == ""){
+                const titleInput = document.getElementById('title_' + this.component_id);
+                titleInput.focus();
+                this.highlightTitleInput = true;
+                return;
+            }
             let method = this.method.toLowerCase();
             this.form.description = tinyMCE.get('description').getContent();
             if (method === 'patch') {
@@ -249,3 +258,9 @@ export default {
     },
 };
 </script>
+
+<style scoped>
+.missing-input {
+    border-color: red !important;
+}
+</style>


### PR DESCRIPTION
This makes the title focused and marked red if you try to save without a title. Previously, saving just failed without any feedback to the user on an empty title.