### PR TITLE
Changes in Plans | Fixes

### DIFF
--- a/app/Http/Controllers/PlanEntryController.php
+++ b/app/Http/Controllers/PlanEntryController.php
@@ -123,7 +123,15 @@ class PlanEntryController extends Controller
      */
     public function destroy(PlanEntry $planEntry)
     {
-        abort_unless(\Gate::allows('plan_delete'), 403);
+        abort_unless((\Gate::allows('plan_delete') and $planEntry->isAccessible()), 403);
+
+        $planEntry->enablingObjectiveSubscriptions()->delete();
+        $planEntry->terminalObjectiveSubscriptions()->delete();
+        // trainings need to be deleted separately
+        foreach ($planEntry->trainings as $training) {
+            $training->exercises()->delete();
+            (new TrainingController())->destroy($training);
+        }
 
         $planEntry->delete();
 

--- a/resources/js/components/kanban/KanbanBoard.vue
+++ b/resources/js/components/kanban/KanbanBoard.vue
@@ -654,7 +654,7 @@ export default {
 .kanban_board_wrapper {
     position: absolute;
     height: 100%;
-    width: 100%;
+    width: 100% !important;
     padding: 2rem;
     overflow-y: clip;
     overflow-x: overlay;

--- a/resources/js/components/kanban/KanbanBoard.vue
+++ b/resources/js/components/kanban/KanbanBoard.vue
@@ -108,7 +108,6 @@
                                         :item="item"
                                         :width="itemWidth"
                                         :kanban_owner_id="kanban.owner_id"
-                                        style="min-height: 150px"
                                         v-on:item-destroyed="handleItemDestroyedWithoutWebsocket"
                                         v-on:item-updated="handleItemUpdatedWithoutWebsocket"
                                         v-on:item-edit=""

--- a/resources/js/components/kanban/KanbanItem.vue
+++ b/resources/js/components/kanban/KanbanItem.vue
@@ -1,6 +1,12 @@
 <template>
-    <div class="card">
-        <div class="card-header px-3 py-2" :style="{ backgroundColor: item.color, color: textColor }">
+    <div :id="'kanban-item-' + item.id" class="card">
+        <div
+            class="card-header px-3 py-2"
+            :style="{ backgroundColor: item.color, color: textColor }"
+            data-toggle="collapse"
+            :data-target="'#kanban-item-' + item.id + ' > .card-body:not(.editor)'"
+            aria-expanded="true"
+        >
             <div class="card-tools">
                 <div v-if="
                         (editable == true && item.editable == true && editor == false && onlyEditOwnedItems != true) ||
@@ -94,12 +100,12 @@
             </div>
 
         </div>
-        <div class="card-body p-0">
+        <div class="card-body p-0 collapse show" :class="editor ? 'editor' : ''">
             <div v-if="(editor == false)">
-                <div v-if="item.description !== null "
+                <div
                      class="text-muted small px-3 py-2"
-                     v-dompurify-html="form.description">
-                </div>
+                     v-dompurify-html="form.description ?? '<p>&#8288;</p>'"
+                ></div>
             </div>
 
             <div v-if="(editor !== false)"

--- a/resources/js/components/kanban/KanbanItem.vue
+++ b/resources/js/components/kanban/KanbanItem.vue
@@ -1,5 +1,5 @@
 <template>
-    <div :id="'kanban-item-' + item.id" class="card">
+    <div :id="'kanban-item-' + item.id" class="card" :class="editor ? 'editor' : ''">
         <div
             class="card-header px-3 py-2"
             :style="{ backgroundColor: item.color, color: textColor }"
@@ -527,6 +527,9 @@ export default {
 }
 </script>
 <style scoped>
+:not(.editor) > .card-header:hover {
+    background-color: #e0e0e0 !important;
+}
 .due-date {
     color: #6c757d;
     font-size: 12px;

--- a/resources/js/components/media/MediumForm.vue
+++ b/resources/js/components/media/MediumForm.vue
@@ -87,7 +87,7 @@ export default {
         removeSubscription() {
             //! temporary solution to remove media for Logbooks/Kanbans
             this.$parent.removeMedium();
-            axios.post('mediumSubscriptions/destroy', {
+            axios.post('/mediumSubscriptions/destroy', {
                 'medium_id': this.medium_id,
                 'subscribable_id': this.referenceable_id,
                 'subscribable_type': this.referenceable_type,

--- a/resources/js/components/objectives/Objectives.vue
+++ b/resources/js/components/objectives/Objectives.vue
@@ -7,7 +7,7 @@
                 class="row">  <!-- terminalObjective -->
                 <div class="col-12">
                     <div class="card-tools pull-right">
-                        <span v-if="is_owner()">
+                        <span v-if="is_owner() && editable">
                             <a @click="destroy(subscription)" >
                                 <i class="fas fa-trash text-danger pointer"></i>
                             </a>

--- a/resources/js/components/objectives/Objectives.vue
+++ b/resources/js/components/objectives/Objectives.vue
@@ -6,7 +6,7 @@
             <div v-if="typeof (subscription.enabling_objective) == 'undefined'"
                 class="row">  <!-- terminalObjective -->
                 <div class="col-12">
-                    <div v-if="is_owner() && editable" class="card-tools pull-right h-100">
+                    <div v-if="is_owner() && editable" class="card-tools text-right">
                         <span>
                             <a @click="destroy(subscription)" >
                                 <i class="fas fa-trash text-danger pointer"></i>

--- a/resources/js/components/objectives/Objectives.vue
+++ b/resources/js/components/objectives/Objectives.vue
@@ -6,8 +6,8 @@
             <div v-if="typeof (subscription.enabling_objective) == 'undefined'"
                 class="row">  <!-- terminalObjective -->
                 <div class="col-12">
-                    <div class="card-tools pull-right">
-                        <span v-if="is_owner() && editable">
+                    <div v-if="is_owner() && editable" class="card-tools pull-right h-100">
+                        <span>
                             <a @click="destroy(subscription)" >
                                 <i class="fas fa-trash text-danger pointer"></i>
                             </a>

--- a/resources/js/components/plan/Plan.vue
+++ b/resources/js/components/plan/Plan.vue
@@ -83,7 +83,6 @@
                 </div>
 
                 <div class="col-12">
-                    <!--<Calendar></Calendar>-->
                     <PlanEntry
                         v-if="$userId == plan.owner_id"
                         :plan="plan"
@@ -128,7 +127,6 @@
 <script>
 import draggable from 'vuedraggable';
 
-const Calendar = () => import('../calendar/Calendar');
 const PlanEntry = () => import('./PlanEntry');
 const PlanIndexAddWidget = () => import('./PlanIndexAddWidget.vue');
 
@@ -266,7 +264,6 @@ export default {
         },
     },
     components: {
-        Calendar,
         PlanEntry,
         PlanIndexAddWidget,
         draggable,

--- a/resources/js/components/plan/Plan.vue
+++ b/resources/js/components/plan/Plan.vue
@@ -13,11 +13,15 @@
                             <span>
                                 <button
                                     @click="openUserModal()"
-                                    class="btn btn-tool text-dark p-0"
+                                    class="btn btn-tool text-dark px-0"
                                     :class="mode_toggle ? 'disabled' : ''"
                                     style="margin-top: -15px;"
                                 >
-                                    Kein Benutzer ausgew&auml;hlt
+                                    {{
+                                        this.selected_user == null
+                                            ? 'Kein Benutzer ausgew&auml;hlt'
+                                            : this.selected_user?.firstname + ' ' + this.selected_user?.lastname
+                                    }}
                                 </button>
                             </span>
                             <a class="link-muted pl-1" style="padding-right: 2px;">
@@ -211,6 +215,7 @@ export default {
         async handleUserModalClose(users, skip = false) {
             if (!this.mode_toggle && !skip) {
                 this.selected_user = users;
+                localStorage.setItem('user-datatable-selection', [users.id]); // used by AchievementIndicator.vue
             } else {
                 const ids = users.map(user => user.id);
                 window.open('/plans/' + this.plan.id + '/getUserAchievements/' + ids);

--- a/resources/js/components/plan/Plan.vue
+++ b/resources/js/components/plan/Plan.vue
@@ -87,11 +87,18 @@
             <!-- * REFERENCE: overlay button in bottom right corner * -->
             <div
                 id="corner-button"
-                class="position-sticky d-flex justify-content-center align-items-center float-right mb-3"
+                class="position-sticky d-flex align-items-center float-right px-3"
                 :style="mode_toggle ? 'display: none !important' : ''"
                 role="button"
                 @click="openUserModal()"
             >
+                <span class="pr-2">
+                    {{
+                        this.selected_user == null
+                            ? trans('global.select_users')
+                            : this.selected_user?.firstname + ' ' + this.selected_user?.lastname
+                    }}
+                </span>
                 <i class="fa fa-user"></i>
             </div>
             <set-achievements-modal
@@ -265,8 +272,8 @@ export default {
 #corner-button {
     color: white;
     background-color: #333;
-    border-radius: 50%;
-    width: 50px;
+    border-radius: 25px;
+    min-width: 50px;
     height: 50px;
     bottom: 25px;
 }

--- a/resources/js/components/plan/Plan.vue
+++ b/resources/js/components/plan/Plan.vue
@@ -17,7 +17,7 @@
                                 <button
                                     @click="openUserModal()"
                                     class="btn btn-tool text-dark px-0"
-                                    :class="mode_toggle ? 'disabled' : ''"
+                                    :disabled="mode_toggle"
                                     style="margin-top: -15px;"
                                 >
                                     {{

--- a/resources/js/components/plan/Plan.vue
+++ b/resources/js/components/plan/Plan.vue
@@ -9,7 +9,10 @@
                         v-can="'plan_edit'"
                         class="card-tools pr-2 no-print user-select-none"
                     >
-                        <span class="mr-3">
+                        <span
+                            class="mr-3"
+                            :title="mode_toggle ? 'Kompetenz anklicken um mehrere Personen einzuschätzen' : 'Einschätzungen für einzelne Person abgeben'"
+                        >
                             <span>
                                 <button
                                     @click="openUserModal()"
@@ -41,8 +44,12 @@
                         <a onclick="window.print()" class="link-muted mr-3 px-1 pointer">
                             <i class="fa fa-print"></i>
                         </a>
-                        <a v-if="$userId == plan.owner_id" @click="openEditModal()" class="link-muted px-1 pointer">
+                        <a v-if="editable" class="link-muted px-1">
                             <i class="fa fa-pencil-alt"></i>
+                            <span class="custom-switch custom-switch-on-green pull-right" style="margin-right: -6px;">
+                                <input type="checkbox" id="edit_toggle" class="custom-control-input" v-model="edit_toggle">
+                                <label for="edit_toggle" class="custom-control-label pointer"></label>
+                            </span>
                         </a>
                     </div>
                 </div>
@@ -68,7 +75,7 @@
                         <PlanEntry
                             v-for="(entry, index) in entries"
                             :key="entries[index].id"
-                            :editable="editable"
+                            :editable="editable && edit_toggle"
                             :entry="entry"
                             :plan="plan"
                         ></PlanEntry>
@@ -141,6 +148,7 @@ export default {
             subscriptions: {},
             disabled: true, // false => only plan-owner
             mode_toggle: true, // true => all users | false => single user
+            edit_toggle: true,
             selected_user: null,
             errors: {},
         }
@@ -205,9 +213,6 @@ export default {
                     }
                 }
             });
-        },
-        openEditModal() {
-            this.$eventHub.$emit('edit_plan', this.plan);
         },
         openUserModal(showAchievements) {
             // if the user-modal should be skipped and only one user is selected

--- a/resources/js/components/plan/Plan.vue
+++ b/resources/js/components/plan/Plan.vue
@@ -9,10 +9,7 @@
                         v-can="'plan_edit'"
                         class="card-tools pr-2 no-print user-select-none"
                     >
-                        <span
-                            class="mr-3"
-                            :title="mode_toggle ? 'Kompetenz anklicken um mehrere Personen einzuschätzen' : 'Einschätzungen für einzelne Person abgeben'"
-                        >
+                        <span class="mr-3">
                             <span>
                                 <button
                                     @click="openUserModal()"
@@ -27,16 +24,23 @@
                                     }}
                                 </button>
                             </span>
-                            <a class="link-muted pl-1" style="padding-right: 2px;">
-                                <i class="fa fa-user"></i>
-                            </a>
-                            <span class="custom-switch custom-switch-on-green" style="margin-right: -6px;">
-                                <input type="checkbox" id="mode_toggle" class="custom-control-input" v-model="mode_toggle">
-                                <label for="mode_toggle" class="custom-control-label pointer"></label>
+                            <span class="tooltip-container">
+                                <span class="tooltip-wrapper">
+                                    <span class="tooltip-text">
+                                        {{ mode_toggle ? 'Kompetenz anklicken um mehrere Personen einzuschätzen' : 'Einschätzungen für einzelne Person abgeben' }}
+                                    </span>
+                                </span>
+                                <a class="link-muted" style="padding-left: 6px; margin-right: -4px">
+                                    <i class="fa fa-user"></i>
+                                </a>
+                                <span class="custom-switch custom-switch-on-green" style="padding-left: 44px;">
+                                    <input type="checkbox" id="mode_toggle" class="custom-control-input" v-model="mode_toggle">
+                                    <label for="mode_toggle" class="custom-control-label pointer"></label>
+                                </span>
+                                <a class="link-muted" style="margin-left: -4px;">
+                                    <i class="fa fa-users"></i>
+                                </a>
                             </span>
-                            <a class="link-muted pr-1">
-                                <i class="fa fa-users"></i>
-                            </a>
                         </span>
                         <a @click="openUserModal(!mode_toggle)" class="link-muted mr-3 px-1 pointer">
                             <i class="fa fa-chart-simple"></i>
@@ -292,6 +296,40 @@ export default {
 }
 </script>
 <style scoped>
+.tooltip-container {
+    position: relative;
+
+    & .tooltip-wrapper {
+        position: absolute;
+        bottom: 40px;
+        left: 50%;
+        width: max-content;
+        z-index: 1;
+
+
+        & .tooltip-text {
+            visibility: hidden;
+            position: relative;
+            margin-left: -50%;
+            background-color: #555;
+            color: #fff;
+            border-radius: 6px;
+            padding: 5px;
+            
+            &::after {
+                content: "";
+                position: absolute;
+                top: 100%;
+                left: 50%;
+                margin-left: -5px;
+                border-width: 5px;
+                border-style: solid;
+                border-color: #555 transparent transparent transparent;
+            }
+        }
+    }
+    &:hover .tooltip-wrapper .tooltip-text { visibility: visible; }
+}
 #corner-button {
     color: white;
     background-color: #333;

--- a/resources/js/components/plan/PlanAchievements.vue
+++ b/resources/js/components/plan/PlanAchievements.vue
@@ -39,6 +39,7 @@ export default {
             const terminal_tr = document.createElement('tr');
             const terminal_td = document.createElement('td');
 
+            terminal_tr.id = 'terminal_' + ter.terminal_objective_id;
             terminal_tr.classList.add('thick-line');
             terminal_td.innerHTML = ter.terminal_objective.title;
 
@@ -57,6 +58,40 @@ export default {
 
                 tbody.appendChild(enabling_tr);
             })
+        });
+
+        achievements.enabling.forEach(ena => {
+            let terminal_tr = document.getElementById('terminal_' + ena.enabling_objective.terminal_objective_id);
+            const enabling_tr = document.createElement('tr');
+            const enabling_td = document.createElement('td');
+
+            // if terminal-objective doesn't exist, create a new terminal-row
+            if (terminal_tr === null) {
+                const tr = document.createElement('tr');
+                const td = document.createElement('td');
+
+                tr.id = 'terminal_' + ena.enabling_objective.terminal_objective_id;
+                tr.classList.add('thick-line');
+                td.innerHTML = ena.enabling_objective.terminal_objective.title;
+
+                tr.appendChild(td);
+                tbody.appendChild(tr);
+
+                terminal_tr = tr; // save newly created terminal-tr to append the enabling-tr
+            }
+            
+            // create an enabling-row
+            enabling_td.innerHTML = ena.enabling_objective.title;
+            enabling_tr.appendChild(enabling_td);
+
+            this.addAchievementCells(enabling_tr, ena.enabling_objective.achievements);
+
+            // find its last enabling-objective tr
+            const last_enabling =
+                $(terminal_tr).closest('tr').nextAll('.thick-line')[0]?.previousElementSibling // search next terminal-tr
+                ?? terminal_tr.parentElement.lastElementChild; // if there's no next terminal-tr, get last tr of table
+            // and add the new enabling-row
+            last_enabling.after(enabling_tr);
         });
     },
     methods: {

--- a/resources/js/components/plan/PlanEntry.vue
+++ b/resources/js/components/plan/PlanEntry.vue
@@ -24,7 +24,7 @@
                                 <i class="fa fa-pencil-alt mr-2 pointer link-muted"
                                    @click="edit()"></i>
                                 <i class="fas fa-trash pointer text-danger"
-                                   @click="destroy(entry)"></i>
+                                   @click.stop="$parent.$parent.confirmEntryDelete(entry.id)"></i>
                             </div>
                         </div>
                         <div class="card-body py-2 collapse">
@@ -192,15 +192,6 @@ export default {
             this.$nextTick(() => {
                 this.$initTinyMCE("autolink link");
             });
-        },
-        destroy(entry){
-            axios.delete('/planEntries/'+entry.id)
-                .then(response => {
-                    this.$eventHub.$emit("plan_entry_deleted", entry);
-                })
-                .catch(e => {
-                    console.log(e);
-                });
         },
         submit() {
             let method = this.method.toLowerCase();

--- a/resources/js/components/users/SelectUsersModal.vue
+++ b/resources/js/components/users/SelectUsersModal.vue
@@ -107,6 +107,11 @@ export default {
         beforeClose() {},
         opened() {},
         beforeOpen() {},
+    },
+    watch: {
+        multiple() {
+            this.selectedUsers = [];
+        },
     }
 }
 </script>

--- a/resources/lang/de/global.php
+++ b/resources/lang/de/global.php
@@ -214,6 +214,7 @@ return [
     'user_management' => 'Benutzerverwaltung',
     'users' => 'Benutzer',
     'select_users' => 'Benutzer auswählen',
+    'no_user_selected' => 'Kein Benutzer ausgewählt',
     'user' => [
         'title' => 'Benutzer',
         'title_singular' => 'Benutzer',
@@ -867,7 +868,8 @@ return [
         'create' => 'Eintrag erstellen',
         'search' => 'Eintrag suchen',
         'edit' => 'Eintrag bearbeiten',
-
+        'delete' => 'Eintrag löschen',
+        'delete_helper' => 'Soll der Eintrag sowie die zugehörigen Daten gelöscht werden?',
     ],
     'training' => [
         'title' => 'Trainings',

--- a/resources/lang/de/global.php
+++ b/resources/lang/de/global.php
@@ -884,7 +884,7 @@ return [
         'search' => 'Übung suchen',
         'edit' => 'Übung bearbeiten',
         'fields' => [
-            'recommended_iterations' => 'Wie oft soll die Übung wiederholt werden? / Wie viele Zeit soll geübt werden?'
+            'recommended_iterations' => 'Wie oft soll die Übung wiederholt werden? / Wie viel Zeit soll geübt werden?'
         ]
     ],
     'exercisedone' => [

--- a/resources/lang/en/global.php
+++ b/resources/lang/en/global.php
@@ -860,23 +860,23 @@ return [
     'training' => [
         'title' => 'Trainings',
         'title_singular' => 'Training',
-        'create' => 'Training erstellen',
-        'search' => 'Training suchen',
-        'edit' => 'Training bearbeiten',
+        'create' => 'Create training',
+        'search' => 'Search training',
+        'edit' => 'Edit training',
     ],
     'exercise' => [
-        'title' => 'exercises',
-        'title_singular' => 'exercise',
-        'create' => 'create exercise',
-        'search' => 'search exercise',
-        'edit' => 'edit exerciese',
+        'title' => 'Exercises',
+        'title_singular' => 'Exercise',
+        'create' => 'Create exercise',
+        'search' => 'Search exercise',
+        'edit' => 'Edit exerciese',
         'fields' => [
-            'recommended_iterations' => 'Wie oft soll die Übung wiederholt werden?'
+            'recommended_iterations' => 'How often should this exercise be repeated? / How much time should be exercised?'
         ]
     ],
     'exercisedone' => [
         'fields' => [
-            'iterations' => 'Iterations'
+            'iterations' => 'Iterations / Time'
         ]
     ],
     'contactdetail' => [

--- a/resources/lang/en/global.php
+++ b/resources/lang/en/global.php
@@ -204,6 +204,7 @@ return [
     'user_management' => 'Users',
     'users' => 'Users',
     'select_users' => 'Select users',
+    'no_user_selected' => 'No user selected',
     'user' => [
         'title' => 'Users',
         'title_singular' => 'User',
@@ -853,7 +854,8 @@ return [
         'create' => 'Create entry',
         'search' => 'Search entries',
         'edit' => 'Edit entry',
-
+        'delete' => 'Delete Entry',
+        'delete_helper' => 'Should this entry and all its corresponding data be deleted?',
     ],
     'training' => [
         'title' => 'Trainings',

--- a/resources/views/plans/show.blade.php
+++ b/resources/views/plans/show.blade.php
@@ -4,6 +4,11 @@
     {{ $plan->title }}
     @can('plan_create')
         @if (Auth::user()->id ==  $plan->owner_id)
+            <a class="btn btn-flat"
+                onclick="app.__vue__.$eventHub.$emit('edit_plan', {{ $plan->toJson() }})"
+            >
+                <i class="fa fa-pencil-alt text-secondary"></i>
+            </a>
             <button class="btn btn-flat"
                     onclick="app.__vue__.$modal.show('subscribe-modal',  {'modelId': {{ $plan->id }}, 'modelUrl': 'plan' });">
                 <i class="fa fa-share-alt text-secondary"></i>


### PR DESCRIPTION
Plans:
- completed opening the achievements-overview in a new tab instead of the print-dialog
- added toggle for 'single-user'-mode
- added toggle to hide edit/delete-icons in entries
- added tooltip for 'single-user'-mode toggle
- fixed the delete-button (for an objective) pushing down a single ObjectiveBox
- added 'confirm-delete'-modal when deleting PlanEntry

Fixes;
- fixed 'delete medium' not working inside Kanban/Logbook
- removed currently unused Calendar-component inside Plan
- deleting a PlanEntry now correctly deletes its subscriptions
- KanbanItem can now open/close its body when clicking on its header
- KanbanBoard width should now always be correct, independent of layout or sidebar