### PR TITLE
fixed pinia-subscribe throwing error in PROD

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "scripts": {
         "dev": "vite",
         "build": "vite build",
-        "preview": "vite build & vite preview",
+        "preview": "vite build && vite preview",
         "production": "vite build",
         "cypress": "start php artisan serve --env=cypress --port=8001 && start npx cypress open"
     },

--- a/resources/js/components/absence/AbsenceModal.vue
+++ b/resources/js/components/absence/AbsenceModal.vue
@@ -106,90 +106,89 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import Editor from '@tinymce/tinymce-vue';
-    import VueDatePicker from '@vuepic/vue-datepicker';
-    import '@vuepic/vue-datepicker/dist/main.css';
-    import {useGlobalStore} from "../../store/global";
-    import Select2 from "../forms/Select2.vue";
+import Form from 'form-backend-validation';
+import Editor from '@tinymce/tinymce-vue';
+import VueDatePicker from '@vuepic/vue-datepicker';
+import '@vuepic/vue-datepicker/dist/main.css';
+import {useGlobalStore} from "../../store/global";
+import Select2 from "../forms/Select2.vue";
 
-    export default {
-        name: 'absence-modal',
-        components:{
-            Select2,
-            Editor,
-            VueDatePicker
-        },
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
+export default {
+    name: 'absence-modal',
+    components: {
+        Select2,
+        Editor,
+        VueDatePicker
+    },
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/absences',
+            form: new Form({
+                'id':'',
+                'reason': '',
+                'absent_user_id': '',
+                'referenceable_type': null,
+                'referenceable_id': null,
+                'done': false,
+                'time': 0
+            }),
+        }
+    },
+    methods: {
+        submit(method) {
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/absences',
-                form: new Form({
-                    'id':'',
-                    'reason': '',
-                    'absent_user_id': '',
-                    'referenceable_type': null,
-                    'referenceable_id': null,
-                    'done': false,
-                    'time': 0
-                }),
-            }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('absence-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-
-        methods: {
-             submit(method) {
-                 if (method == 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('absence-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('absence-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
+        update() {
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('absence-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
+            }
+        });
 
-            this.form.start_date = new Date();
-        },
-    }
+        this.form.start_date = new Date();
+    },
+}
 </script>
 

--- a/resources/js/components/config/ConfigModal.vue
+++ b/resources/js/components/config/ConfigModal.vue
@@ -120,80 +120,80 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import axios from "axios";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import axios from "axios";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'config-modal',
-        components:{},
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
+export default {
+    name: 'config-modal',
+    components:{},
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
 
-            return {
-                globalStore,
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/configs',
+            form: new Form({
+                'id':'',
+                'key': '',
+                'value': '',
+                'referenceable_type': '',
+                'referenceable_id': '',
+                'data_type': '',
+            }),
+            search: '',
+        }
+    },
+    methods: {
+        submit(method) {
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/configs',
-                form: new Form({
-                    'id':'',
-                    'key': '',
-                    'value': '',
-                    'referenceable_type': '',
-                    'referenceable_id': '',
-                    'data_type': '',
-                }),
-                search: '',
-            }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('config-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        methods: {
-            submit(method) {
-                if (method == 'patch') {
-                    this.update();
-                } else {
-                    this.add();
-                }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('config-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('config-updated', r.data);
-                    })
-                    .catch(error => { // Handle the error returned from our request
-                        console.log(error);
-                    });
-            }
-        },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+        update() {
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('config-updated', r.data);
+                })
+                .catch(error => { // Handle the error returned from our request
+                    console.log(error);
+                });
+        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id !== ''){
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>

--- a/resources/js/components/contactDetail/ContactModal.vue
+++ b/resources/js/components/contactDetail/ContactModal.vue
@@ -107,102 +107,102 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import Editor from '@tinymce/tinymce-vue';
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import Editor from '@tinymce/tinymce-vue';
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'contact-modal',
-        components:{
-            Editor,
-        },
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
+export default {
+    name: 'contact-modal',
+    components:{
+        Editor,
+    },
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
 
-            return {
-                globalStore,
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/contactDetails',
+            form: new Form({
+                'id':'',
+                'email': '',
+                'phone': '',
+                'mobile': '',
+                'notes': '',
+            }),
+            countries: [],
+            states: [],
+            tinyMCE: this.$initTinyMCE(
+                [
+                    "advlist autolink lists link image charmap print preview hr anchor pagebreak",
+                    "searchreplace wordcount visualblocks visualchars code fullscreen",
+                    "insertdatetime media nonbreaking save table directionality",
+                    "emoticons template paste textpattern curriculummedia"
+                ],
+                {
+                    'eventHubCallbackFunction': 'insertContent',
+                    'eventHubCallbackFunctionParams': this.component_id,
+
+                },
+                " | customDateButton | insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | example link image media | insertFirstname insertLastname organizationTitle organizationStreet organizationPostcode organizationCity contactDetailDate | usersProgress",
+                "span[id|class|style|name|reference_type|reference_id|min_value]",
+            ),
+
+            search: '',
+        }
+    },
+    methods: {
+        submit(method) {
+            this.form.notes = tinyMCE.get('notes').getContent();
+
+            if (method === 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/contactDetails',
-                form: new Form({
-                    'id':'',
-                    'email': '',
-                    'phone': '',
-                    'mobile': '',
-                    'notes': '',
-                }),
-                countries: [],
-                states: [],
-                tinyMCE: this.$initTinyMCE(
-                    [
-                        "advlist autolink lists link image charmap print preview hr anchor pagebreak",
-                        "searchreplace wordcount visualblocks visualchars code fullscreen",
-                        "insertdatetime media nonbreaking save table directionality",
-                        "emoticons template paste textpattern curriculummedia"
-                    ],
-                    {
-                        'eventHubCallbackFunction': 'insertContent',
-                        'eventHubCallbackFunctionParams': this.component_id,
-
-                    },
-                    " | customDateButton | insertfile undo redo | styleselect | bold italic | alignleft aligncenter alignright alignjustify | bullist numlist outdent indent | example link image media | insertFirstname insertLastname organizationTitle organizationStreet organizationPostcode organizationCity contactDetailDate | usersProgress",
-                    "span[id|class|style|name|reference_type|reference_id|min_value]",
-                ),
-
-                search: '',
-            }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('contactDetail-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        methods: {
-             submit(method) {
-                this.form.notes = tinyMCE.get('notes').getContent();
-
-                if (method === 'patch') {
-                    this.update();
-                } else {
-                    this.add();
-                }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('contactDetail-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update(){
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('contactDetail-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            }
-        },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        this.form.notes = this.$decodeHtml(this.form.notes)
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+        update() {
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('contactDetail-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    this.form.notes = this.$decodeHtml(this.form.notes)
+                    if (this.form.id !== ''){
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>

--- a/resources/js/components/content/ContentSubscriptionModal.vue
+++ b/resources/js/components/content/ContentSubscriptionModal.vue
@@ -81,64 +81,64 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import Editor from '@tinymce/tinymce-vue';
-    import Select2 from "../forms/Select2.vue";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import Editor from '@tinymce/tinymce-vue';
+import Select2 from "../forms/Select2.vue";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'content-subscription-modal',
-        components:{
-            Editor,
-            Select2
+export default {
+    name: 'content-subscription-modal',
+    components: {
+        Editor,
+        Select2
+    },
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            url: '/contents',
+            curriculum_id: null,
+            form: new Form({
+                'content_id': [],
+                'subscribable_type': null,
+                'subscribable_id': null,
+            }),
+        }
+    },
+    methods: {
+        submit() {
+            axios.post('/contentSubscriptions', this.form)
+                .then(r => {
+                    this.$eventHub.emit('content-added', r.data);
+                    // vorher: this.$parent.$emit('addContent', this.form);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
-            }
-        },
-        data() {
-            return {
-                component_id: this.$.uid,
-                url: '/contents',
-                curriculum_id: null,
-                form: new Form({
-                    'content_id': [],
-                    'subscribable_type': null,
-                    'subscribable_id': null,
-                }),
-            }
-        },
-        methods: {
-             submit() {
-                 axios.post('/contentSubscriptions', this.form)
-                     .then(r => {
-                         this.$eventHub.emit('content-added', r.data);
-                         // vorher: this.$parent.$emit('addContent', this.form);
-                     })
-                     .catch(e => {
-                         console.log(e.response);
-                     });
-            },
-        },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id !== ''){
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>

--- a/resources/js/components/course/CourseModal.vue
+++ b/resources/js/components/course/CourseModal.vue
@@ -68,7 +68,7 @@ export default {
         Select2
     },
     props: {},
-    setup () {
+    setup() {
         const globalStore = useGlobalStore();
         return {
             globalStore,
@@ -96,7 +96,7 @@ export default {
                 this.add();
             }
         },
-        add(){
+        add() {
             axios.post(this.url, {
                 'enrollment_list' : {
                     0: {
@@ -118,10 +118,10 @@ export default {
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params;
                 this.form.reset();
-                if (typeof (params) !== 'undefined'){
+                if (typeof (params) !== 'undefined') {
                     this.form.populate(params);
                     this.method = 'post';
                 }

--- a/resources/js/components/curriculum/CurriculumModal.vue
+++ b/resources/js/components/curriculum/CurriculumModal.vue
@@ -285,128 +285,128 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import Editor from '@tinymce/tinymce-vue';
-    import MediumModal from "../media/MediumModal.vue";
-    import MediumForm from "../media/MediumForm.vue";
-    import Select2 from "../forms/Select2.vue";
-    import VueDatePicker from '@vuepic/vue-datepicker';
-    import axios from "axios";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import Editor from '@tinymce/tinymce-vue';
+import MediumModal from "../media/MediumModal.vue";
+import MediumForm from "../media/MediumForm.vue";
+import Select2 from "../forms/Select2.vue";
+import VueDatePicker from '@vuepic/vue-datepicker';
+import axios from "axios";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'curriculum-modal',
-        components:{
-            Editor,
-            MediumModal,
-            MediumForm,
-            Select2,
-            VueDatePicker
-        },
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
-            }
-        },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/curricula',
-                files: null,
-                form: new Form({
-                    'id':'',
-                    'title': '',
-                    'description': '',
-                    'author': '',
-                    'publisher': '',
-                    'city': '',
-                    'date': '',
-                    'color': '#F2C511',
-                    'grade_id': 1,
-                    'subject_id': 1,
-                    'organization_type_id': 1,
-                    'state_id': 'DE-RP',
-                    'country_id': 'DE',
-                    'medium_id': null,
-                    'owner_id': '',
-                    'type_id': 4,
-                }),
-                tinyMCE: this.$initTinyMCE(
-                    [
-                        "autolink link table lists"
-                    ],
-                    {
-                        'eventHubCallbackFunction': 'insertContent',
-                        'eventHubCallbackFunctionParams': this.component_id,
-                    }
-                ),
-                search: '',
-            }
-        },
-        computed:{
-            textColor: function(){
-                return this.$textcolor(this.form.color, '#333333');
-            }
-        },
-        methods: {
-            submit(method) {
-                this.form.description = tinyMCE.get('description').getContent();
-                if (method === 'patch') {
-                    this.update();
-                } else {
-                    this.add();
+export default {
+    name: 'curriculum-modal',
+    components:{
+        Editor,
+        MediumModal,
+        MediumForm,
+        Select2,
+        VueDatePicker
+    },
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/curricula',
+            files: null,
+            form: new Form({
+                'id':'',
+                'title': '',
+                'description': '',
+                'author': '',
+                'publisher': '',
+                'city': '',
+                'date': '',
+                'color': '#F2C511',
+                'grade_id': 1,
+                'subject_id': 1,
+                'organization_type_id': 1,
+                'state_id': 'DE-RP',
+                'country_id': 'DE',
+                'medium_id': null,
+                'owner_id': '',
+                'type_id': 4,
+            }),
+            tinyMCE: this.$initTinyMCE(
+                [
+                    "autolink link table lists"
+                ],
+                {
+                    'eventHubCallbackFunction': 'insertContent',
+                    'eventHubCallbackFunctionParams': this.component_id,
                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('curriculum-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('curriculum-updated', r.data);
-                    })
-                    .catch(error => { // Handle the error returned from our request
-                        console.log(error);
-                    });
-            },
-            onChange($events){
-                this.files = $events.target.files;
-                console.log(this.files);
-                axios.post('curricula/import/store', this.files)
-                    .then(r => {
-                        this.$eventHub.emit('curriculum-imported', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
+            ),
+            search: '',
+        }
+    },
+    computed: {
+        textColor: function() {
+            return this.$textcolor(this.form.color, '#333333');
+        }
+    },
+    methods: {
+        submit(method) {
+            this.form.description = tinyMCE.get('description').getContent();
+            if (method === 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id !== ''){
-                            this.form.description = this.$decodeHTMLEntities(this.form.body);
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('curriculum-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+        update() {
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('curriculum-updated', r.data);
+                })
+                .catch(error => { // Handle the error returned from our request
+                    console.log(error);
+                });
+        },
+        onChange($events) {
+            this.files = $events.target.files;
+            console.log(this.files);
+            axios.post('curricula/import/store', this.files)
+                .then(r => {
+                    this.$eventHub.emit('curriculum-imported', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id !== ''){
+                        this.form.description = this.$decodeHTMLEntities(this.form.body);
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>

--- a/resources/js/components/exam/ExamModal.vue
+++ b/resources/js/components/exam/ExamModal.vue
@@ -71,80 +71,79 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import Select2 from "../forms/Select2.vue";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import Select2 from "../forms/Select2.vue";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'exam-modal',
-        components:{
-            Select2
+export default {
+    name: 'exam-modal',
+    components:{
+        Select2
+    },
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/exams',
+            form: new Form({
+                'exam_id':'',
+                'group_id': '',
+            }),
+            search: '',
+            options: []
+        }
+    },
+    methods: {
+        submit() {
+            let test = this.options.filter((t) => t.id == this.form.exam_id);
+            //console.log(test[0]);
+            this.SendCreateExamRequest(test[0].tool, test[0].id, test[0].nameLong, this.form.group_id);
         },
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
-            }
-        },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/exams',
-                form: new Form({
-                    'exam_id':'',
-                    'group_id': '',
-                }),
-                search: '',
-                options: []
-            }
-        },
-        methods: {
-
-            submit() {
-                let test = this.options.filter((t) => t.id == this.form.exam_id);
-                //console.log(test[0]);
-                this.SendCreateExamRequest(test[0].tool, test[0].id, test[0].nameLong, this.form.group_id);
-            },
-            async SendCreateExamRequest(tool, test_id, test_name, group_id) {
-                console.log({'tool': tool, 'test_id': test_id, 'test_name': test_name, 'group_id': group_id})
-                await axios.post('/exams', {'tool': tool, 'test_id': test_id, 'test_name': test_name, 'group_id': group_id})
-                    .then(response => {
-                        this.$eventHub.emit('exam-added', response.data)
-                    })
-                    .catch(errors => {
-                        this.$emit('failedNotification', errors)
-                    })
-            }
-        },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
-                    }
-                }
-            });
-
-            axios.get('/tests')
+        async SendCreateExamRequest(tool, test_id, test_name, group_id) {
+            console.log({'tool': tool, 'test_id': test_id, 'test_name': test_name, 'group_id': group_id})
+            await axios.post('/exams', {'tool': tool, 'test_id': test_id, 'test_name': test_name, 'group_id': group_id})
                 .then(response => {
-                    this.options = response.data
+                    this.$eventHub.emit('exam-added', response.data)
                 })
                 .catch(errors => {
-                    if (errors.response.status !== 403) {
-                        this.$emit('failedNotification', Vue.prototype.trans('global.exam.error_messages.get_tests'))
-                    }
+                    this.$emit('failedNotification', errors)
                 })
-        },
-    }
+        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
+                    }
+                }
+            }
+        });
+
+        axios.get('/tests')
+            .then(response => {
+                this.options = response.data
+            })
+            .catch(errors => {
+                if (errors.response.status !== 403) {
+                    this.$emit('failedNotification', Vue.prototype.trans('global.exam.error_messages.get_tests'))
+                }
+            })
+    },
+}
 </script>
 

--- a/resources/js/components/exam/SubscribeExamModal.vue
+++ b/resources/js/components/exam/SubscribeExamModal.vue
@@ -63,11 +63,11 @@ import {useGlobalStore} from "../../store/global";
 
 export default {
     name: 'subscribe-exam-modal',
-    components:{
+    components: {
         Select2
     },
     props: {},
-    setup () {
+    setup() {
         const globalStore = useGlobalStore();
         return {
             globalStore,
@@ -109,12 +109,12 @@ export default {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
 
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params.reference;
                 this.subscribable_type = state.modals[this.$options.name].params.subscribable_type;
                 this.subscribable_id = state.modals[this.$options.name].params.subscribable_id;
                 this.form.reset();
-                if (typeof (params) !== 'undefined'){
+                if (typeof (params) !== 'undefined') {
                     this.form.populate(params);
                     this.method = 'post';
                 }

--- a/resources/js/components/grade/GradeModal.vue
+++ b/resources/js/components/grade/GradeModal.vue
@@ -117,100 +117,100 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import {useGlobalStore} from "../../store/global";
-    import Select2 from "../forms/Select2.vue";
+import Form from 'form-backend-validation';
+import {useGlobalStore} from "../../store/global";
+import Select2 from "../forms/Select2.vue";
 
-    export default {
-        name: 'grade-modal',
-        components:{
-            Select2,
-        },
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
-            }
-        },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/grades',
-                form: new Form({
-                    'id':'',
-                    'title': '',
-                    'external_begin': null,
-                    'external_end': null,
-                    'organization_type_id': 1
-                }),
-                countries: [],
-                states: [],
-                tinyMCE: this.$initTinyMCE(
-                    [
-                        "autolink link curriculummedia"
-                    ],
-                    {
-                        'eventHubCallbackFunction': 'insertContent',
-                        'eventHubCallbackFunctionParams': this.component_id,
-                    }
-                ),
-                search: '',
-            }
-        },
-        methods: {
-             submit(method) {
-                 this.form.begin = this.form.date[0];
-                 this.form.end = this.form.date[1];
+export default {
+    name: 'grade-modal',
+    components:{
+        Select2,
+    },
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/grades',
+            form: new Form({
+                'id':'',
+                'title': '',
+                'external_begin': null,
+                'external_end': null,
+                'organization_type_id': 1
+            }),
+            countries: [],
+            states: [],
+            tinyMCE: this.$initTinyMCE(
+                [
+                    "autolink link curriculummedia"
+                ],
+                {
+                    'eventHubCallbackFunction': 'insertContent',
+                    'eventHubCallbackFunctionParams': this.component_id,
+                }
+            ),
+            search: '',
+        }
+    },
+    methods: {
+        submit(method) {
+            this.form.begin = this.form.date[0];
+            this.form.end = this.form.date[1];
 
-                 if (method == 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('grade-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('grade-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        this.form.date = [this.form.begin, this.form.end];
-                        if (this.form.id != ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('grade-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+        update() {
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('grade-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    this.form.date = [this.form.begin, this.form.end];
+                    if (this.form.id != '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
+            }
+        });
 
-            const startDate = new Date();
-            const endDate = new Date(new Date().setDate(startDate.getDate() + 7));
-            this.form.date = [startDate, endDate];
-        },
-    }
+        const startDate = new Date();
+        const endDate = new Date(new Date().setDate(startDate.getDate() + 7));
+        this.form.date = [startDate, endDate];
+    },
+}
 </script>
 

--- a/resources/js/components/group/GroupModal.vue
+++ b/resources/js/components/group/GroupModal.vue
@@ -115,7 +115,7 @@ export default {
         Select2
     },
     props: {},
-    setup () {
+    setup() {
         const globalStore = useGlobalStore();
         return {
             globalStore
@@ -144,7 +144,7 @@ export default {
                 this.add();
             }
         },
-        add(){
+        add() {
             axios.post(this.url, this.form)
                 .then(r => {
                     this.$eventHub.emit('group-added', r.data);
@@ -153,7 +153,7 @@ export default {
                     console.log(e.response);
                 });
         },
-        update(){
+        update() {
             axios.patch(this.url + '/' + this.form.id, this.form)
                 .then(r => {
                     this.$eventHub.emit('group-updated', r.data);
@@ -166,12 +166,12 @@ export default {
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params;
                 this.form.reset();
-                if (typeof (params) !== 'undefined'){
+                if (typeof (params) !== 'undefined') {
                     this.form.populate(params);
-                    if (this.form.id != ''){
+                    if (this.form.id != '') {
                         this.method = 'patch';
                     } else {
                         this.method = 'post';

--- a/resources/js/components/kanban/KanbanStatusModal.vue
+++ b/resources/js/components/kanban/KanbanStatusModal.vue
@@ -223,7 +223,7 @@ export default {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
 
-            if (mutation.events.key === this.$options.name) {
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params;
                 this.form.reset();
                 if (typeof (params) !== 'undefined') {

--- a/resources/js/components/kanban/SubscribeKanbanModal.vue
+++ b/resources/js/components/kanban/SubscribeKanbanModal.vue
@@ -66,7 +66,7 @@ export default {
         Select2
     },
     props: {},
-    setup () {
+    setup() {
         const globalStore = useGlobalStore();
         return {
             globalStore,
@@ -105,12 +105,12 @@ export default {
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params.reference;
                 this.subscribable_type = state.modals[this.$options.name].params.subscribable_type;
                 this.subscribable_id = state.modals[this.$options.name].params.subscribable_id;
                 this.form.reset();
-                if (typeof (params) !== 'undefined'){
+                if (typeof (params) !== 'undefined') {
                     this.form.populate(params);
                     this.method = 'post';
                 }

--- a/resources/js/components/lms/LmsModal.vue
+++ b/resources/js/components/lms/LmsModal.vue
@@ -126,224 +126,220 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import Select2 from "../forms/Select2.vue";
-    import {useGlobalStore} from "../../store/global";
-    import Token from "./Token.vue";
-    import {useToast} from "vue-toastification";
+import Form from 'form-backend-validation';
+import Select2 from "../forms/Select2.vue";
+import {useGlobalStore} from "../../store/global";
+import Token from "./Token.vue";
+import {useToast} from "vue-toastification";
 
-
-    export default {
-        name: 'lms-modal',
-        components:{
-            Token,
-            Select2,
-        },
-        props: {
-            params: {
-                type: Object
-            },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
-        },
-        setup () {
-            const toast = useToast();
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
-                toast
-            }
-        },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/lmsReferences',
-                form: new Form({
-                    'id': null,
-                    'referenceable_type': null,
-                    'referenceable_id': null,
-                    'course_id': null,
-                    'course_content_id': null,
-                    'course_item': null,
-                    'sharing_level': 2,
-                }),
-                token: false,
-                lms_url: '',
-                courses: [],
-                course_contents: [],
-                course_content_items: [],
-                sharing_levels: [],
-                loading: false
-            }
-        },
-        methods: {
-             loader() {
-                this.course_contents = [];
-                this.course_content_items = [];
-                this.course_content_id = null;
-                this.course_item = null;
-                axios.get('/lmsUserTokens')
-                    .then(response => {
-                        this.token      = response.data.token;
-                        this.lms_url    = response.data.lms_url;
-                        if (this.lms_url !== ''){
-                            this.getTokenFromLms(this.lms_url + '/mod/curriculum/get_token.php');
-                        }
-                    }).catch(e => {
-                        console.log(e);
-                    });
-            },
-            loadCourses() {
-                this.loading = true;
-                this.course_content_items = [];
-                this.course_item = null;
-                axios.post(this.url + '/get', {
-                        plugin: 'moodle',
-                        ws_function: 'core_course_get_courses_by_field',
-                    })
-                    .then(r => {
-                        //console.log(r.data);
-                        this.courses = r.data
-                        this.loading = false;
-                    }).catch(e => {
-                        console.log(e);
-                    });
-            },
-            loadCourseContents(course_id) {
-                this.loading = true;
-                this.form.course_id = parseInt(course_id)
-                axios.post(this.url + '/get', {
-                    plugin: 'moodle',
-                    ws_function: 'core_course_get_contents',
-                    course_id: course_id
-                })
-                    .then(r => {
-                        //console.log(r.data);
-                        this.course_contents = r.data
-                        if (typeof (this.course_contents.exception) !== "undefined") {
-                            if (this.course_contents.exception == "moodle_exception") {
-                                alert(this.course_contents.message);
-                            }
-                        }
-                        this.loading = false;
-                    }).catch(e => {
+export default {
+    name: 'lms-modal',
+    components:{
+        Token,
+        Select2,
+    },
+    props: {
+        params: {
+            type: Object
+        },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
+    },
+    setup() {
+        const toast = useToast();
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+            toast
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/lmsReferences',
+            form: new Form({
+                'id': null,
+                'referenceable_type': null,
+                'referenceable_id': null,
+                'course_id': null,
+                'course_content_id': null,
+                'course_item': null,
+                'sharing_level': 2,
+            }),
+            token: false,
+            lms_url: '',
+            courses: [],
+            course_contents: [],
+            course_content_items: [],
+            sharing_levels: [],
+            loading: false
+        }
+    },
+    methods: {
+        loader() {
+            this.course_contents = [];
+            this.course_content_items = [];
+            this.course_content_id = null;
+            this.course_item = null;
+            axios.get('/lmsUserTokens')
+                .then(response => {
+                    this.token      = response.data.token;
+                    this.lms_url    = response.data.lms_url;
+                    if (this.lms_url !== ''){
+                        this.getTokenFromLms(this.lms_url + '/mod/curriculum/get_token.php');
+                    }
+                }).catch(e => {
                     console.log(e);
                 });
-
-            },
-            loadCourseItems(id) {
-                this.form.course_content_id = parseInt(id)
-                const index = this.course_contents.findIndex(
-                    c => c.id === parseInt(id)
-                );
-                this.course_content_items = this.course_contents[index].modules
-            },
-            setItems(id){
-                const index = this.course_content_items.findIndex(            // Find the index of the status where we should replace the item
-                    i => i.id === parseInt(id)
-                );
-                this.form.course_item = this.course_content_items[index]
-            },
-
-             submit(method) {
-                 if (this.form.course_item != null) {
-                     if (method == 'patch') {
-                         this.update();
-                     } else {
-                         this.add();
-                     }
-                 } else {
-                     this.errorNotification('Bitte alle Felder auswählen.');
-                 }
-
-            },
-            add(){
-                axios.post(this.url, {
-                    'plugin': 'moodle',
-                    'course_id': this.form.course_id,
-                    'course_content_id': this.form.course_content_id,
-                    'course_item': this.form.course_item,
-                    'referenceable_type': this.form.referenceable_type,
-                    'referenceable_id': this.form.referenceable_id,
-                    'sharing_level': this.form.sharing_level,
-                })
-                    .then(r => {
-                        this.$eventHub.emit('lms-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('lms-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            async getTokenFromLms(url) {
-                axios.get(url)
-                    .then(response => {
-                        this.token = response.data.privatetoken ;
-                        this.setUserToken();
-                    })
-                    .catch(e => {
-                        console.log(e);
-                    });
-            },
-            async setUserToken() {
-                try {
-                    const token = (await axios.post('/lmsUserTokens',
-                        {
-                            'token': this.form.token,
-                        })).data.token;
-                    this.$emit('newToken', token)
-
-                } catch (error) {
-                    console.log(error);
-                }
-            },
-            onNewToken(token) {
-                this.token = token;
-                this.loadCourses();
-            },
-            errorNotification(message) {
-                this.toast.error(message, {
-                    position: "top-right",
-                    timeout: 3000,
-                    closeOnClick: true,
-                    pauseOnFocusLoss: true,
-                    pauseOnHover: true,
-                    draggable: true,
-                    draggablePercent: 0.6,
-                    showCloseButtonOnHover: false,
-                    hideProgressBar: true,
-                    closeButton: "button",
-                    icon: true,
-                    rtl: false
-                });
-            },
         },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id != ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
+        loadCourses() {
+            this.loading = true;
+            this.course_content_items = [];
+            this.course_item = null;
+            axios.post(this.url + '/get', {
+                    plugin: 'moodle',
+                    ws_function: 'core_course_get_courses_by_field',
+                })
+                .then(r => {
+                    //console.log(r.data);
+                    this.courses = r.data
+                    this.loading = false;
+                }).catch(e => {
+                    console.log(e);
+                });
+        },
+        loadCourseContents(course_id) {
+            this.loading = true;
+            this.form.course_id = parseInt(course_id)
+            axios.post(this.url + '/get', {
+                plugin: 'moodle',
+                ws_function: 'core_course_get_contents',
+                course_id: course_id
+            })
+                .then(r => {
+                    //console.log(r.data);
+                    this.course_contents = r.data
+                    if (typeof (this.course_contents.exception) !== "undefined") {
+                        if (this.course_contents.exception == "moodle_exception") {
+                            alert(this.course_contents.message);
                         }
                     }
-                }
+                    this.loading = false;
+                }).catch(e => {
+                console.log(e);
             });
+        },
+        loadCourseItems(id) {
+            this.form.course_content_id = parseInt(id)
+            const index = this.course_contents.findIndex(
+                c => c.id === parseInt(id)
+            );
+            this.course_content_items = this.course_contents[index].modules
+        },
+        setItems(id) {
+            const index = this.course_content_items.findIndex(            // Find the index of the status where we should replace the item
+                i => i.id === parseInt(id)
+            );
+            this.form.course_item = this.course_content_items[index]
+        },
+        submit(method) {
+            if (this.form.course_item != null) {
+                if (method == 'patch') {
+                    this.update();
+                } else {
+                    this.add();
+                }
+            } else {
+                this.errorNotification('Bitte alle Felder auswählen.');
+            }
+        },
+        add() {
+            axios.post(this.url, {
+                'plugin': 'moodle',
+                'course_id': this.form.course_id,
+                'course_content_id': this.form.course_content_id,
+                'course_item': this.form.course_item,
+                'referenceable_type': this.form.referenceable_type,
+                'referenceable_id': this.form.referenceable_id,
+                'sharing_level': this.form.sharing_level,
+            })
+                .then(r => {
+                    this.$eventHub.emit('lms-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+        update() {
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('lms-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+        async getTokenFromLms(url) {
+            axios.get(url)
+                .then(response => {
+                    this.token = response.data.privatetoken ;
+                    this.setUserToken();
+                })
+                .catch(e => {
+                    console.log(e);
+                });
+        },
+        async setUserToken() {
+            try {
+                const token = (await axios.post('/lmsUserTokens',
+                    {
+                        'token': this.form.token,
+                    })).data.token;
+                this.$emit('newToken', token)
 
-            this.loader();
+            } catch (error) {
+                console.log(error);
+            }
+        },
+        onNewToken(token) {
+            this.token = token;
             this.loadCourses();
         },
-    }
+        errorNotification(message) {
+            this.toast.error(message, {
+                position: "top-right",
+                timeout: 3000,
+                closeOnClick: true,
+                pauseOnFocusLoss: true,
+                pauseOnHover: true,
+                draggable: true,
+                draggablePercent: 0.6,
+                showCloseButtonOnHover: false,
+                hideProgressBar: true,
+                closeButton: "button",
+                icon: true,
+                rtl: false
+            });
+        },
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id != ''){
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
+                    }
+                }
+            }
+        });
+
+        this.loader();
+        this.loadCourses();
+    },
+}
 </script>

--- a/resources/js/components/logbook/Logbook.vue
+++ b/resources/js/components/logbook/Logbook.vue
@@ -180,12 +180,11 @@ export default {
         });
 
         this.$eventHub.on('update-subject-badge', (updatedEntry) => {
-            console.log(updatedEntry);
             this.globalStore?.closeModal('logbook-entry-subject-modal');
             const index = this.entries.findIndex(
                 entry => entry.id === updatedEntry.entry_id
             );
-            //console.log(this.entries[index]);
+
             this.entries[index].subject = {
                 id: updatedEntry.subject_id,
                 title: updatedEntry.title

--- a/resources/js/components/logbook/Logbook.vue
+++ b/resources/js/components/logbook/Logbook.vue
@@ -154,11 +154,12 @@ export default {
 
         this.currentLogbook = this.logbook;
 
-        this.$eventHub.on('logbookEntry-added', (entry) => {
+        this.$eventHub.on('logbook-entry-added', (entry) => {
             this.globalStore?.closeModal('logbook-entry-modal');
             this.entries.push(entry);
         });
-        this.$eventHub.on('logbookEntry-updated', (updated) => {
+
+        this.$eventHub.on('logbook-entry-updated', (updated) => {
             this.globalStore?.closeModal('logbook-entry-modal');
 
             const index = this.entries.findIndex(
@@ -168,12 +169,17 @@ export default {
             Object.assign(this.entries[index], updated);
         });
 
+        this.$eventHub.on('logbook-entry-deleted', (deletedEntry) => {
+            let index = this.entries.indexOf(deletedEntry);
+            this.entries.splice(index, 1);
+        });
+
         this.$eventHub.on('logbook-updated', (logbook) => {
             this.globalStore?.closeModal('logbook-modal');
             this.currentLogbook = logbook;
         });
 
-        this.$eventHub.on('updateSubjectBadge', (updatedEntry) => {
+        this.$eventHub.on('update-subject-badge', (updatedEntry) => {
             console.log(updatedEntry);
             this.globalStore?.closeModal('logbook-entry-subject-modal');
             const index = this.entries.findIndex(
@@ -185,11 +191,6 @@ export default {
                 title: updatedEntry.title
             };
             this.entries[index].subject_id = updatedEntry.subject_id;
-        });
-
-        this.$eventHub.on('deleteLogbookEntry', function (deletedEntry) {
-            let index = this.entries.indexOf(deletedEntry);
-            this.entries.splice(index, 1);
         });
     },
     methods: {

--- a/resources/js/components/logbook/LogbookModal.vue
+++ b/resources/js/components/logbook/LogbookModal.vue
@@ -143,7 +143,7 @@ export default {
         Select2
     },
     props: {},
-    setup () {
+    setup() {
         const globalStore = useGlobalStore();
         return {
             globalStore,
@@ -206,7 +206,7 @@ export default {
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params;
                 this.form.reset();
                 if (typeof (params) !== 'undefined'){

--- a/resources/js/components/logbook/SubscribeLogbookModal.vue
+++ b/resources/js/components/logbook/SubscribeLogbookModal.vue
@@ -66,7 +66,7 @@ export default {
         Select2
     },
     props: {},
-    setup () {
+    setup() {
         const globalStore = useGlobalStore();
         return {
             globalStore,
@@ -105,12 +105,12 @@ export default {
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params.reference;
                 this.subscribable_type = state.modals[this.$options.name].params.subscribable_type;
                 this.subscribable_id = state.modals[this.$options.name].params.subscribable_id;
                 this.form.reset();
-                if (typeof (params) !== 'undefined'){
+                if (typeof (params) !== 'undefined') {
                     this.form.populate(params);
                     this.method = 'post';
                 }

--- a/resources/js/components/logbookEntry/LogbookEntry.vue
+++ b/resources/js/components/logbookEntry/LogbookEntry.vue
@@ -223,9 +223,7 @@
         </div>
     </div>
 </template>
-
 <script>
-
 import Absences from '../absence/Absences.vue';
 import Contents from '../content/Contents.vue';
 import Tasks from '../task/Tasks.vue';
@@ -243,7 +241,7 @@ export default {
         'first': false,
         'editable': false,
     },
-    setup () {
+    setup() {
         const globalStore = useGlobalStore();
         return {
             globalStore,
@@ -273,13 +271,10 @@ export default {
                     'title': this.entry.subject?.title
                 });
         },
-        async destroy(){
-            try {
-                this.location = (await axios.delete('/logbookEntries/' + this.entry.id)).data.message;
-            } catch (error) {
-                console.log(error);
-            }
-            this.$eventHub.emit('deleteLogbookEntry',this.entry);
+        destroy() {
+            axios.delete('/logbookEntries/' + this.entry.id)
+                .then(response => this.$eventHub.emit('logbook-entry-deleted', this.entry))
+                .catch(error => console.log(error));
         },
         postDate() {
             if (this.entry.begin == undefined || this.entry.end == undefined) {
@@ -308,7 +303,6 @@ export default {
             }
         },
         isEditableForUser() {
-
             const exists = this.logbook.subscriptions.findIndex(            // Is editable?
                 subscription => subscription.subscribable_type === "App\\User" && subscription.subscribable_id == this.$userId && subscription.editable === 1
             );

--- a/resources/js/components/logbookEntry/LogbookEntryModal.vue
+++ b/resources/js/components/logbookEntry/LogbookEntryModal.vue
@@ -154,7 +154,7 @@ export default {
         add() {
             axios.post(this.url, this.form)
                 .then(r => {
-                    this.$eventHub.emit('logbookEntry-added', r.data);
+                    this.$eventHub.emit('logbook-entry-added', r.data);
                 })
                 .catch(e => {
                     console.log(e.response);
@@ -163,7 +163,7 @@ export default {
         update() {
             axios.patch(this.url + '/' + this.form.id, this.form)
                 .then(r => {
-                    this.$eventHub.emit('logbookEntry-updated', r.data);
+                    this.$eventHub.emit('logbook-entry-updated', r.data);
                 })
                 .catch(e => {
                     console.log(e.response);

--- a/resources/js/components/logbookEntry/LogbookEntryModal.vue
+++ b/resources/js/components/logbookEntry/LogbookEntryModal.vue
@@ -109,7 +109,7 @@ export default {
         Select2
     },
     props: {},
-    setup () {
+    setup() {
         const globalStore = useGlobalStore();
         return {
             globalStore,
@@ -176,10 +176,10 @@ export default {
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params;
                 this.form.reset();
-                if (typeof (params) !== 'undefined'){
+                if (typeof (params) !== 'undefined') {
                     this.form.populate(params);
                     this.form.date = [this.form.begin ?? '', this.form.end ?? ''];
                     this.form.description = this.htmlToText(params.description);

--- a/resources/js/components/logbookEntry/LogbookEntrySubjectModal.vue
+++ b/resources/js/components/logbookEntry/LogbookEntrySubjectModal.vue
@@ -65,7 +65,7 @@ export default {
         Select2
     },
     props: {},
-    setup () {
+    setup() {
         const globalStore = useGlobalStore();
         return {
             globalStore,
@@ -84,7 +84,7 @@ export default {
         }
     },
     methods: {
-        submit(){
+        submit() {
             axios.patch(this.url + '/' + this.form.id + '/setSubject', this.form)
                 .then(r => {
                     this.$eventHub.emit('update-subject-badge', {
@@ -101,10 +101,10 @@ export default {
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params;
                 this.form.reset();
-                if (typeof (params) !== 'undefined'){
+                if (typeof (params) !== 'undefined') {
                     this.form.populate(params);
                 }
             }

--- a/resources/js/components/logbookEntry/LogbookEntrySubjectModal.vue
+++ b/resources/js/components/logbookEntry/LogbookEntrySubjectModal.vue
@@ -87,7 +87,7 @@ export default {
         submit(){
             axios.patch(this.url + '/' + this.form.id + '/setSubject', this.form)
                 .then(r => {
-                    this.$eventHub.emit('updateSubjectBadge', {
+                    this.$eventHub.emit('update-subject-badge', {
                         entry_id: this.form.id,
                         subject_id:  r.data.id,
                         title:  r.data.title,

--- a/resources/js/components/map/MapModal.vue
+++ b/resources/js/components/map/MapModal.vue
@@ -205,111 +205,111 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import MediumModal from "../media/MediumModal.vue";
-    import axios from "axios";
-    import Editor from "@tinymce/tinymce-vue";
-    import Select2 from "../forms/Select2.vue";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import MediumModal from "../media/MediumModal.vue";
+import axios from "axios";
+import Editor from "@tinymce/tinymce-vue";
+import Select2 from "../forms/Select2.vue";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'map-modal',
-        components:{
-            Editor,
-            MediumModal,
-            Select2
-        },
-        props: {},
-        setup () { //https://pinia.vuejs.org/core-concepts/getters.html#passing-arguments-to-getters
-            const globalStore = useGlobalStore();
-            return {
-                globalStore
+export default {
+    name: 'map-modal',
+    components:{
+        Editor,
+        MediumModal,
+        Select2
+    },
+    props: {},
+    setup() { //https://pinia.vuejs.org/core-concepts/getters.html#passing-arguments-to-getters
+        const globalStore = useGlobalStore();
+        return {
+            globalStore
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/maps',
+            form: new Form({
+                'id':'',
+                'title':'',
+                'subtitle':'',
+                'description': '',
+                'tags': '',
+                'type_id': 2,
+                'category_id': 2,
+                'border_url': '',
+                'latitude': 49,
+                'longitude': 8,
+                'zoom': 10,
+                'color': '#F2C511',
+                'medium_id': '',
+            }),
+            search: '',
+            tinyMCE: this.$initTinyMCE(
+                [
+                    "autolink link curriculummedia"
+                ],
+                {
+                    'eventHubCallbackFunction': 'insertContent',
+                    'eventHubCallbackFunctionParams': this.component_id,
+                }
+            ),
+        }
+    },
+    computed: {
+        textColor: function() {
+            return this.$textcolor(this.form.color, '#333333');
+        }
+    },
+    methods: {
+        submit(method) {
+            this.form.description = tinyMCE.get('description').getContent();
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/maps',
-                form: new Form({
-                    'id':'',
-                    'title':'',
-                    'subtitle':'',
-                    'description': '',
-                    'tags': '',
-                    'type_id': 2,
-                    'category_id': 2,
-                    'border_url': '',
-                    'latitude': 49,
-                    'longitude': 8,
-                    'zoom': 10,
-                    'color': '#F2C511',
-                    'medium_id': '',
-                }),
-                search: '',
-                tinyMCE: this.$initTinyMCE(
-                    [
-                        "autolink link curriculummedia"
-                    ],
-                    {
-                        'eventHubCallbackFunction': 'insertContent',
-                        'eventHubCallbackFunctionParams': this.component_id,
-                    }
-                ),
-            }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('map-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        computed:{
-            textColor: function(){
-                return this.$textcolor(this.form.color, '#333333');
-            }
+        update() {
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('map-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        methods: {
-             submit(method) {
-                 this.form.description = tinyMCE.get('description').getContent();
-                 if (method == 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('map-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('map-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-        },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        this.form.border_url = this.$decodeHTMLEntities(params.border_url);
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    this.form.border_url = this.$decodeHTMLEntities(params.border_url);
 
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>
 

--- a/resources/js/components/map/MarkerModal.vue
+++ b/resources/js/components/map/MarkerModal.vue
@@ -237,111 +237,111 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import MediumModal from "../media/MediumModal.vue";
-    import axios from "axios";
-    import Editor from "@tinymce/tinymce-vue";
-    import Select2 from "../forms/Select2.vue";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import MediumModal from "../media/MediumModal.vue";
+import axios from "axios";
+import Editor from "@tinymce/tinymce-vue";
+import Select2 from "../forms/Select2.vue";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'map-marker-modal',
-        components:{
-            Editor,
-            MediumModal,
-            Select2
-        },
-        props: {
-            map: {
-                type: Object
+export default {
+    name: 'map-marker-modal',
+    components: {
+        Editor,
+        MediumModal,
+        Select2
+    },
+    props: {
+        map: {
+            type: Object
+        }
+    },
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/mapMarkers',
+            form: new Form({
+                'id':'',
+                'title':'',
+                'teaser_tesxt':'',
+                'description': '',
+                'author': '',
+                'type_id': 1,
+                'category_id': 1,
+                'tags': '',
+                'latitude': null,
+                'longitude': null,
+                'address': '',
+                'url': '',
+                'url_title': '',
+                'map_id': '',
+            }),
+            tinyMCE: this.$initTinyMCE(
+                [
+                    "autolink link curriculummedia"
+                ],
+                {
+                    'eventHubCallbackFunction': 'insertContent',
+                    'eventHubCallbackFunctionParams': this.component_id,
+                }
+            ),
+        }
+    },
+    methods: {
+        submit(method) {
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
-            }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('marker-added', r.data.marker);
+                    this.globalStore?.closeModal(this.$options.name)
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/mapMarkers',
-                form: new Form({
-                    'id':'',
-                    'title':'',
-                    'teaser_tesxt':'',
-                    'description': '',
-                    'author': '',
-                    'type_id': 1,
-                    'category_id': 1,
-                    'tags': '',
-                    'latitude': null,
-                    'longitude': null,
-                    'address': '',
-                    'url': '',
-                    'url_title': '',
-                    'map_id': '',
-                }),
-                tinyMCE: this.$initTinyMCE(
-                    [
-                        "autolink link curriculummedia"
-                    ],
-                    {
-                        'eventHubCallbackFunction': 'insertContent',
-                        'eventHubCallbackFunctionParams': this.component_id,
-                    }
-                ),
-            }
+        update() {
+            console.log('update');
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('marker-updated', r.data.marker);
+                    this.globalStore?.closeModal(this.$options.name)
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        methods: {
-             submit(method) {
-                 if (method == 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('marker-added', r.data.marker);
-                        this.globalStore?.closeModal(this.$options.name)
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                console.log('update');
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('marker-updated', r.data.marker);
-                        this.globalStore?.closeModal(this.$options.name)
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-        },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        this.form.url = this.$decodeHTMLEntities(params.url);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    this.form.url = this.$decodeHTMLEntities(params.url);
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>
 

--- a/resources/js/components/metadataset/MetadatasetModal.vue
+++ b/resources/js/components/metadataset/MetadatasetModal.vue
@@ -57,76 +57,76 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import axios from "axios";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import axios from "axios";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'metadataset-modal',
-        components:{},
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
+export default {
+    name: 'metadataset-modal',
+    components: {},
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/metadatasets',
+            form: new Form({
+                'id': '',
+                'version':  '',
+            }),
+        }
+    },
+    methods: {
+        submit(method) {
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/metadatasets',
-                form: new Form({
-                    'id': '',
-                    'version':  '',
-                }),
-            }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('metadataset-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        methods: {
-             submit(method) {
-                 if (method == 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('metadataset-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                console.log('update');
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('metadataset-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
+        update() {
+            console.log('update');
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('metadataset-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>
 

--- a/resources/js/components/note/NoteModal.vue
+++ b/resources/js/components/note/NoteModal.vue
@@ -43,51 +43,51 @@
     </Transition>
 </template>
 <script>
-    import Notes from "./Notes.vue";
-    import Form from 'form-backend-validation';
-    import {useGlobalStore} from "../../store/global";
+import Notes from "./Notes.vue";
+import Form from 'form-backend-validation';
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'note-modal',
-        components:{
-            Notes,
-        },
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
-            }
-        },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                form: new Form({
-                    'notable_type': false,
-                    'notable_id': false,
-                    'show_tabs': true,
-                }),
-            }
-        },
-        methods: {},
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+export default {
+    name: 'note-modal',
+    components: {
+        Notes,
+    },
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            form: new Form({
+                'notable_type': false,
+                'notable_id': false,
+                'show_tabs': true,
+            }),
+        }
+    },
+    methods: {},
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>
 

--- a/resources/js/components/objectives/SubscribeObjectiveModal.vue
+++ b/resources/js/components/objectives/SubscribeObjectiveModal.vue
@@ -113,7 +113,7 @@ export default {
             type: Object
         },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
     },
-    setup () { //use database store
+    setup() { //use database store
         const globalStore = useGlobalStore();
         return {
             globalStore
@@ -140,7 +140,7 @@ export default {
             this.form.populate(newVal);
             this.url = newVal.url;
 
-            if (this.form.id != null){
+            if (this.form.id != null) {
                 this.method = 'patch';
             } else {
                 this.method = 'post';
@@ -148,7 +148,7 @@ export default {
         },
     },
     methods: {
-        submit(){
+        submit() {
             if (this.form.enabling_objective_id == null) {
                 this.url = '/terminalObjectiveSubscriptions';
                 this.form.terminal_objective_id.forEach( id => {
@@ -190,10 +190,10 @@ export default {
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params;
                 this.form.reset();
-                if (typeof (params) !== 'undefined'){
+                if (typeof (params) !== 'undefined') {
                     this.form.populate(params);
                     if (this.form.id != ''){
                         this.method = 'patch';

--- a/resources/js/components/objectives/TerminalObjectiveModal.vue
+++ b/resources/js/components/objectives/TerminalObjectiveModal.vue
@@ -119,109 +119,109 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import MediumModal from "../media/MediumModal.vue";
-    import axios from "axios";
-    import Editor from "@tinymce/tinymce-vue";
-    import Select2 from "../forms/Select2.vue";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import MediumModal from "../media/MediumModal.vue";
+import axios from "axios";
+import Editor from "@tinymce/tinymce-vue";
+import Select2 from "../forms/Select2.vue";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'terminal-objective-modal',
-        components:{
-            Editor,
-            MediumModal,
-            Select2,
-        },
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
-            }
-        },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/terminalObjectives',
-                form: new Form({
-                    'id': '',
-                    'title': '',
-                    'description': '',
-                    'color': '#008000',
-                    'time_approach': '',
-                    'curriculum_id': '',
-                    'objective_type_id': 1,
-                    'visibility': true,
+export default {
+    name: 'terminal-objective-modal',
+    components: {
+        Editor,
+        MediumModal,
+        Select2,
+    },
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/terminalObjectives',
+            form: new Form({
+                'id': '',
+                'title': '',
+                'description': '',
+                'color': '#008000',
+                'time_approach': '',
+                'curriculum_id': '',
+                'objective_type_id': 1,
+                'visibility': true,
+            }),
+            tinyMCE: this.$initTinyMCE(
+                [
+                    "autolink link curriculummedia table lists"
+                ],
+                {
+                    'public': 1,
+                    'referenceable_type': 'App\\\Curriculum',
+                    'referenceable_id': this.form?.curriculum_id,
+                    'eventHubCallbackFunction': 'insertContent',
+                    'eventHubCallbackFunctionParams': this.component_id
                 }),
-                tinyMCE: this.$initTinyMCE(
-                    [
-                        "autolink link curriculummedia table lists"
-                    ],
-                    {
-                        'public': 1,
-                        'referenceable_type': 'App\\\Curriculum',
-                        'referenceable_id': this.form?.curriculum_id,
-                        'eventHubCallbackFunction': 'insertContent',
-                        'eventHubCallbackFunctionParams': this.component_id
-                    }),
+        }
+    },
+    computed: {
+        textColor: function() {
+            return this.$textcolor(this.form.color, '#333333');
+        }
+    },
+    methods: {
+        submit(method) {
+            this.form.title = tinyMCE.get('title').getContent();
+            this.form.description = tinyMCE.get('description').getContent();
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        computed:{
-            textColor: function(){
-                return this.$textcolor(this.form.color, '#333333');
-            }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('terminalObjective-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        methods: {
-             submit(method) {
-                 this.form.title = tinyMCE.get('title').getContent();
-                 this.form.description = tinyMCE.get('description').getContent();
-                 if (method == 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('terminalObjective-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                console.log('update');
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('terminalObjective-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
+        update() {
+            console.log('update');
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('terminalObjective-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        this.form.title = this.$decodeHTMLEntities(this.form.title);
-                        this.form.description = this.$decodeHtml(this.form.description);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    this.form.title = this.$decodeHTMLEntities(this.form.title);
+                    this.form.description = this.$decodeHtml(this.form.description);
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>
 

--- a/resources/js/components/organization/OrganizationModal.vue
+++ b/resources/js/components/organization/OrganizationModal.vue
@@ -226,116 +226,116 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import Editor from '@tinymce/tinymce-vue';
-    import Select2 from "../forms/Select2.vue";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import Editor from '@tinymce/tinymce-vue';
+import Select2 from "../forms/Select2.vue";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'organization-modal',
-        components:{
-            Editor,
-            Select2
-        },
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
-            }
-        },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/organizations',
-                form: new Form({
-                    'id':'',
-                    'common_name':'',
-                    'title':'',
-                    'description': '',
-                    'street': '',
-                    'postcode': '',
-                    'city': '',
-                    'state_id': 'DE-RP',
-                    'country_id': 'DE',
-                    'organization_type_id': 1,
-                    'phone': null,
-                    'email': null,
-                    'status_id': 1,
-                    'lms_url': '',
-                }),
-                countries: [],
-                states: [],
-                tinyMCE: this.$initTinyMCE(
-                    [
-                        "autolink link curriculummedia"
-                    ],
-                    {
-                        'eventHubCallbackFunction': 'insertContent',
-                        'eventHubCallbackFunctionParams': this.component_id,
-                    }
-                ),
-                onlyAddress: {
-                    type: Boolean,
-                    default: false
-                },
-                onlyLmsUrl: {
-                    type: Boolean,
-                    default: false
-                },
-                search: '',
-            }
-        },
-        methods: {
-             submit(method) {
-                 if(tinyMCE.get('description')){
-                     this.form.description = tinyMCE.get('description').getContent();
-                 }
-                 if (method === 'patch') {
-                    this.update();
-                 } else {
-                    this.add();
-                 }
+export default {
+    name: 'organization-modal',
+    components: {
+        Editor,
+        Select2
+    },
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/organizations',
+            form: new Form({
+                'id':'',
+                'common_name':'',
+                'title':'',
+                'description': '',
+                'street': '',
+                'postcode': '',
+                'city': '',
+                'state_id': 'DE-RP',
+                'country_id': 'DE',
+                'organization_type_id': 1,
+                'phone': null,
+                'email': null,
+                'status_id': 1,
+                'lms_url': '',
+            }),
+            countries: [],
+            states: [],
+            tinyMCE: this.$initTinyMCE(
+                [
+                    "autolink link curriculummedia"
+                ],
+                {
+                    'eventHubCallbackFunction': 'insertContent',
+                    'eventHubCallbackFunctionParams': this.component_id,
+                }
+            ),
+            onlyAddress: {
+                type: Boolean,
+                default: false
             },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('organization-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
+            onlyLmsUrl: {
+                type: Boolean,
+                default: false
             },
-            update(){
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('organization-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
+            search: '',
+        }
+    },
+    methods: {
+        submit(method) {
+            if(tinyMCE.get('description')){
+                this.form.description = tinyMCE.get('description').getContent();
+            }
+            if (method === 'patch') {
+            this.update();
+            } else {
+            this.add();
             }
         },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        this.form.description = this.$decodeHtml(this.form.description);
-                        this.onlyAddress = params.onlyAddress ?? false;
-                        this.onlyLmsUrl = params.onlyLmsUrl ?? false;
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('organization-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+        update() {
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('organization-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    this.form.description = this.$decodeHtml(this.form.description);
+                    this.onlyAddress = params.onlyAddress ?? false;
+                    this.onlyLmsUrl = params.onlyLmsUrl ?? false;
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>

--- a/resources/js/components/organizationType/OrganizationTypeModal.vue
+++ b/resources/js/components/organizationType/OrganizationTypeModal.vue
@@ -109,80 +109,79 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import Editor from '@tinymce/tinymce-vue';
-    import Select2 from "../forms/Select2.vue";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import Editor from '@tinymce/tinymce-vue';
+import Select2 from "../forms/Select2.vue";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'organization-type-modal',
-        components:{
-            Editor,
-            Select2
-        },
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
+export default {
+    name: 'organization-type-modal',
+    components: {
+        Editor,
+        Select2
+    },
+    props: {},
+    setup () {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/organizationTypes',
+            form: new Form({
+                'id':'',
+                'title': '',
+                'external_id': '',
+                'country_id': 'DE',
+                'state_id': 'DE-RP',
+            }),
+            countries: [],
+            states: [],
+            tinyMCE: this.$initTinyMCE(
+                [
+                    "autolink link curriculummedia"
+                ],
+                {
+                    'eventHubCallbackFunction': 'insertContent',
+                    'eventHubCallbackFunctionParams': this.component_id,
+                }
+            ),
+            search: '',
+        }
+    },
+    methods: {
+        async submit(method) {
+            try {
+                if (method === 'patch') {
+                    this.location = (await axios.patch(this.url + '/' + this.form.id, this.form)).data.message;
+                } else {
+                    this.location = (await axios.post(this.url, this.form)).data.message;
+                }
+            } catch (error) {
+                this.form.errors = error.response.data.form.errors;
             }
         },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/organizationTypes',
-                form: new Form({
-                    'id':'',
-                    'title': '',
-                    'external_id': '',
-                    'country_id': 'DE',
-                    'state_id': 'DE-RP',
-                }),
-                countries: [],
-                states: [],
-                tinyMCE: this.$initTinyMCE(
-                    [
-                        "autolink link curriculummedia"
-                    ],
-                    {
-                        'eventHubCallbackFunction': 'insertContent',
-                        'eventHubCallbackFunctionParams': this.component_id,
-                    }
-                ),
-                search: '',
-            }
-        },
-        methods: {
-
-            async submit(method) {
-                try {
-                    if (method === 'patch') {
-                        this.location = (await axios.patch(this.url + '/' + this.form.id, this.form)).data.message;
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
                     } else {
-                        this.location = (await axios.post(this.url, this.form)).data.message;
-                    }
-                } catch (error) {
-                    this.form.errors = error.response.data.form.errors;
-                }
-            },
-        },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>

--- a/resources/js/components/period/PeriodModal.vue
+++ b/resources/js/components/period/PeriodModal.vue
@@ -73,112 +73,112 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import Editor from '@tinymce/tinymce-vue';
-    import Select2 from "../forms/Select2.vue";
-    import VueDatePicker from '@vuepic/vue-datepicker';
-    import '@vuepic/vue-datepicker/dist/main.css';
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import Editor from '@tinymce/tinymce-vue';
+import Select2 from "../forms/Select2.vue";
+import VueDatePicker from '@vuepic/vue-datepicker';
+import '@vuepic/vue-datepicker/dist/main.css';
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        components:{
-            Editor,
-            Select2,
-            VueDatePicker
+export default {
+    components: {
+        Editor,
+        Select2,
+        VueDatePicker
+    },
+    props: {
+        show: {
+            type: Boolean
         },
-        props: {
-            show: {
-                type: Boolean
-            },
-            params: {
-                type: Object
-            },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
-        },
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
-            }
-        },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/periods',
-                form: new Form({
-                    'id':'',
-                    'title': '',
-                    'date': null,
-                    'begin': new Date(),
-                    'end': null,
-                }),
-                countries: [],
-                states: [],
-                tinyMCE: this.$initTinyMCE(
-                    [
-                        "autolink link curriculummedia"
-                    ],
-                    {
-                        'eventHubCallbackFunction': 'insertContent',
-                        'eventHubCallbackFunctionParams': this.component_id,
-                    }
-                ),
-                search: '',
-            }
-        },
-        methods: {
-             submit(method) {
-                 this.form.begin = this.form.date[0];
-                 this.form.end = this.form.date[1];
+        params: {
+            type: Object
+        },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
+    },
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/periods',
+            form: new Form({
+                'id':'',
+                'title': '',
+                'date': null,
+                'begin': new Date(),
+                'end': null,
+            }),
+            countries: [],
+            states: [],
+            tinyMCE: this.$initTinyMCE(
+                [
+                    "autolink link curriculummedia"
+                ],
+                {
+                    'eventHubCallbackFunction': 'insertContent',
+                    'eventHubCallbackFunctionParams': this.component_id,
+                }
+            ),
+            search: '',
+        }
+    },
+    methods: {
+        submit(method) {
+            this.form.begin = this.form.date[0];
+            this.form.end = this.form.date[1];
 
-                 if (method == 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('period-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                console.log('update');
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('period-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        this.form.date = [this.form.begin, this.form.end];
-                        if (this.form.id != ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('period-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+        update() {
+            console.log('update');
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('period-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    this.form.date = [this.form.begin, this.form.end];
+                    if (this.form.id != '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
+            }
+        });
 
-            const startDate = new Date();
-            const endDate = new Date(new Date().setDate(startDate.getDate() + 7));
-            this.form.date = [startDate, endDate];
-        },
-    }
+        const startDate = new Date();
+        const endDate = new Date(new Date().setDate(startDate.getDate() + 7));
+        this.form.date = [startDate, endDate];
+    },
+}
 </script>
 

--- a/resources/js/components/permission/PermissionModal.vue
+++ b/resources/js/components/permission/PermissionModal.vue
@@ -61,75 +61,75 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'permission-modal',
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
+export default {
+    name: 'permission-modal',
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/permissions',
+            form: new Form({
+                'id':'',
+                'title': '',
+            }),
+            search: '',
+        }
+    },
+    methods: {
+        submit(method) {
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/permissions',
-                form: new Form({
-                    'id':'',
-                    'title': '',
-                }),
-                search: '',
-            }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('permission-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        methods: {
-             submit(method) {
-                 if (method == 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('permission-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                console.log('update');
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('permission-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            }
+        update() {
+            console.log('update');
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('permission-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>
 

--- a/resources/js/components/plan/SetAchievementsModal.vue
+++ b/resources/js/components/plan/SetAchievementsModal.vue
@@ -74,57 +74,57 @@
     </Transition>
 </template>
 <script>
-    import AchievementIndicator from './../objectives/AchievementIndicator.vue';
-    import {useGlobalStore} from "../../store/global";
+import AchievementIndicator from './../objectives/AchievementIndicator.vue';
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'set-achievements-modal',
-        components:{
-            AchievementIndicator
+export default {
+    name: 'set-achievements-modal',
+    components: {
+        AchievementIndicator
+    },
+    props: {
+        users:{},
+    },
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            objective: {},
+            search: '',
+        }
+    },
+    methods: {
+        submit() {
+            this.globalStore?.closeModal($options.name)
         },
-        props: {
-            users:{},
-        },
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+
+                const params = state.modals[this.$options.name].params;
+                console.log(params);
+                const eventObj = params.objective;
+                const obj = {}; // if we add attributes directly to 'this.objective' it won't work
+                obj.default = { id: eventObj.id };
+
+                eventObj.achievements.forEach(achievement => {
+                    // only add attributes that are actually needed
+                    obj[achievement.user_id] = {
+                        id: eventObj.id,
+                        achievements: [achievement],
+                    };
+                });
+
+                this.objective = obj;
             }
-        },
-        data() {
-            return {
-                component_id: this.$.uid,
-                objective: {},
-                search: '',
-            }
-        },
-        methods: {
-             submit() {
-                 this.globalStore?.closeModal($options.name)
-            },
-        },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-
-                    const params = state.modals[this.$options.name].params;
-                    console.log(params);
-                    const eventObj = params.objective;
-                    const obj = {}; // if we add attributes directly to 'this.objective' it won't work
-                    obj.default = { id: eventObj.id };
-
-                    eventObj.achievements.forEach(achievement => {
-                        // only add attributes that are actually needed
-                        obj[achievement.user_id] = {
-                            id: eventObj.id,
-                            achievements: [achievement],
-                        };
-                    });
-
-                    this.objective = obj;
-                }
-            });
-        },
-    }
+        });
+    },
+}
 </script>

--- a/resources/js/components/plan/SubscribePlanModal.vue
+++ b/resources/js/components/plan/SubscribePlanModal.vue
@@ -62,11 +62,11 @@ import {useGlobalStore} from "../../store/global";
 
 export default {
     name: 'subscribe-plan-modal',
-    components:{
+    components: {
         Select2
     },
     props: {},
-    setup () {
+    setup() {
         const globalStore = useGlobalStore();
         return {
             globalStore,
@@ -105,12 +105,12 @@ export default {
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params.reference;
                 this.subscribable_type = state.modals[this.$options.name].params.subscribable_type;
                 this.subscribable_id = state.modals[this.$options.name].params.subscribable_id;
                 this.form.reset();
-                if (typeof (params) !== 'undefined'){
+                if (typeof (params) !== 'undefined') {
                     this.form.populate(params);
                     this.method = 'post';
                 }

--- a/resources/js/components/prerequisites/PrerequisiteObjectiveModal.vue
+++ b/resources/js/components/prerequisites/PrerequisiteObjectiveModal.vue
@@ -103,85 +103,85 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import Select2 from "../forms/Select2.vue";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import Select2 from "../forms/Select2.vue";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'prerequisite-objective-modal',
-        components:{
-            Select2,
-        },
-        props: {
-            params: {
-                type: Object
-            },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
-        },
-        setup () { //use database store
-            const globalStore = useGlobalStore();
-            return {
-                globalStore
+export default {
+    name: 'prerequisite-objective-modal',
+    components: {
+        Select2,
+    },
+    props: {
+        params: {
+            type: Object
+        },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
+    },
+    setup() { //use database store
+        const globalStore = useGlobalStore();
+        return {
+            globalStore
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/prerequisites',
+            form: new Form({
+                'id': null,
+                'successor_type': null,
+                'successor_id': null,
+                'curriculum_id': null,
+                'terminal_objective_id': null,
+                'enabling_objective_id': null,
+            }),
+        }
+    },
+    methods: {
+        submit(method) {
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/prerequisites',
-                form: new Form({
-                    'id': null,
-                    'successor_type': null,
-                    'successor_id': null,
-                    'curriculum_id': null,
-                    'terminal_objective_id': null,
-                    'enabling_objective_id': null,
-                }),
-            }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('prerequisite-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        methods: {
-             submit(method) {
-                 if (method == 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('prerequisite-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('prerequisite-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            }
+        update() {
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('prerequisite-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>
 

--- a/resources/js/components/reference/ReferenceObjectiveModal.vue
+++ b/resources/js/components/reference/ReferenceObjectiveModal.vue
@@ -115,94 +115,94 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import Select2 from "../forms/Select2.vue";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import Select2 from "../forms/Select2.vue";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'reference-objective-modal',
-        components:{
-            Select2,
-        },
-        props: {
-            params: {
-                type: Object
-            },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
-        },
-        setup () { //use database store
-            const globalStore = useGlobalStore();
-            return {
-                globalStore
+export default {
+    name: 'reference-objective-modal',
+    components: {
+        Select2,
+    },
+    props: {
+        params: {
+            type: Object
+        },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
+    },
+    setup() { //use database store
+        const globalStore = useGlobalStore();
+        return {
+            globalStore
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '',
+            form: new Form({
+                'id': null,
+                'subscribable_type': null,
+                'subscribable_id': null,
+                'curriculum_id': null,
+                'terminal_objective_id': null,
+                'enabling_objective_id': null,
+                'description': null
+            }),
+        }
+    },
+    methods: {
+        submit(method) {
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '',
-                form: new Form({
-                    'id': null,
-                    'subscribable_type': null,
-                    'subscribable_id': null,
-                    'curriculum_id': null,
-                    'terminal_objective_id': null,
-                    'enabling_objective_id': null,
-                    'description': null
-                }),
-            }
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('reference-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        methods: {
-             submit(method) {
-                 if (method == 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('reference-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('reference-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            destroy(){
-                axios.delete(this.url + '/' + this.form.id)
-                    .then(r => {this.$eventHub.emit('reference-deleted', r.data );})
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            }
+        update() {
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('reference-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        this.url = params.url;
-                        if (this.form.id != null){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+        destroy() {
+            axios.delete(this.url + '/' + this.form.id)
+                .then(r => {this.$eventHub.emit('reference-deleted', r.data );})
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    this.url = params.url;
+                    if (this.form.id != null) {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>
 

--- a/resources/js/components/role/RoleModal.vue
+++ b/resources/js/components/role/RoleModal.vue
@@ -74,95 +74,93 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import Select2 from "../forms/Select2.vue";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import Select2 from "../forms/Select2.vue";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'role-modal',
-        components:{
-            Select2
-        },
-        props: {
-            params: {
-                type: Object
-            },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
+export default {
+    name: 'role-modal',
+    components: {
+        Select2
+    },
+    props: {
+        params: {
+            type: Object
+        },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
 
-        },
-        setup () { //use database store
-            const globalStore = useGlobalStore();
+    },
+    setup() { //use database store
+        const globalStore = useGlobalStore();
 
-            return {
-                globalStore,
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/roles',
+            form: new Form({
+                'id':'',
+                'title': '',
+                'permissions': '',
+            }),
+            search: '',
+        }
+    },
+    methods: {
+        submit(method) {
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/roles',
-                form: new Form({
-                    'id':'',
-                    'title': '',
-                    'permissions': '',
-                }),
-                search: '',
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('role-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+        update() {
+            console.log('update');
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('role-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+        getSelected() {
+            if (this.form.permissions[0]?.title){
+                return this.form.permissions.map(p => p.id);
+            } else {
+                return this.form.permissions;
             }
         },
-        methods: {
-             submit(method) {
-                 if (method == 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('role-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                console.log('update');
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('role-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            getSelected(){
-                 if (this.form.permissions[0]?.title){
-                     return this.form.permissions.map(p => p.id);
-                 } else {
-                     return this.form.permissions;
-                 }
-
-            }
-        },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                console.log(mutation.events);
-                if (mutation.events?.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>
 

--- a/resources/js/components/subject/SubjectModal.vue
+++ b/resources/js/components/subject/SubjectModal.vue
@@ -81,84 +81,83 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'subject-modal',
-        props: {},
-        setup () { //use database store
-            const globalStore = useGlobalStore();
+export default {
+    name: 'subject-modal',
+    props: {},
+    setup() { //use database store
+        const globalStore = useGlobalStore();
 
-            return {
-                globalStore,
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/subjects',
+            form: new Form({
+                'id':'',
+                'title': '',
+                'title_short': '',
+            }),
+            search: '',
+        }
+    },
+    methods: {
+        submit(method) {
+            if (method == 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/subjects',
-                form: new Form({
-                    'id':'',
-                    'title': '',
-                    'title_short': '',
-                }),
-                search: '',
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('subject-added', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+        update() {
+            console.log('update');
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('subject-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+        getSelected() {
+            if (this.form.permissions[0]?.title){
+                return this.form.permissions.map(p => p.id);
+            } else {
+                return this.form.permissions;
             }
         },
-        methods: {
-             submit(method) {
-                 if (method == 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('subject-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                console.log('update');
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('subject-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            getSelected(){
-                 if (this.form.permissions[0]?.title){
-                     return this.form.permissions.map(p => p.id);
-                 } else {
-                     return this.form.permissions;
-                 }
-
-            }
-        },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        if (this.form.id !== ''){
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    if (this.form.id !== '') {
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
                     }
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>

--- a/resources/js/components/subscription/SubscribeModal.vue
+++ b/resources/js/components/subscription/SubscribeModal.vue
@@ -222,7 +222,7 @@ export default {
             type: Object
         }  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
     },
-    setup () {
+    setup() {
         const globalStore = useGlobalStore();
         return {
             globalStore,
@@ -297,7 +297,7 @@ export default {
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name) {
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params;
 
                 if (typeof (params) !== 'undefined') {

--- a/resources/js/components/user/OwnerModal.vue
+++ b/resources/js/components/user/OwnerModal.vue
@@ -56,55 +56,55 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import {useGlobalStore} from "../../store/global";
-    import Select2 from "../forms/Select2.vue";
+import Form from 'form-backend-validation';
+import {useGlobalStore} from "../../store/global";
+import Select2 from "../forms/Select2.vue";
 
-    export default {
-        name: 'owner-modal',
-        components: {
-            Select2
+export default {
+    name: 'owner-modal',
+    components: {
+        Select2
+    },
+    props: {},
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            form: new Form({
+                'model_id':'',
+                'model': '',
+                'model_url': '',
+                'owner_id': '',
+            }),
+        }
+    },
+    methods: {
+        submit() {
+            axios.patch(this.form.model_url + '/' + this.form.model_id + '/editOwner', this.form)
+                .then(r => {
+                    this.$eventHub.emit('owner-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
         },
-        props: {},
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
-            }
-        },
-        data() {
-            return {
-                component_id: this.$.uid,
-                form: new Form({
-                    'model_id':'',
-                    'model': '',
-                    'model_url': '',
-                    'owner_id': '',
-                }),
-            }
-        },
-        methods: {
-             submit() {
-                 axios.patch(this.form.model_url + '/' + this.form.model_id + '/editOwner', this.form)
-                     .then(r => {
-                         this.$eventHub.emit('owner-updated', r.data);
-                     })
-                     .catch(e => {
-                         console.log(e.response);
-                     });
-            },
-        },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                    }
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
                 }
-            });
-        },
-    }
+            }
+        });
+    },
+}
 </script>

--- a/resources/js/components/user/SubscribeUserModal.vue
+++ b/resources/js/components/user/SubscribeUserModal.vue
@@ -65,7 +65,7 @@ import {useGlobalStore} from "../../store/global";
 
 export default {
     name: 'subscribe-user-modal',
-    components:{
+    components: {
         Select2
     },
     props: {
@@ -73,7 +73,7 @@ export default {
             type: Object
         },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
     },
-    setup () { //https://pinia.vuejs.org/core-concepts/getters.html#passing-arguments-to-getters
+    setup() { //https://pinia.vuejs.org/core-concepts/getters.html#passing-arguments-to-getters
         const globalStore = useGlobalStore();
         return {
             globalStore
@@ -99,8 +99,9 @@ export default {
                 this.add();
             }
         },
-        add(){
-            axios.post(this.url, {
+        add() {
+            axios.post(this.url,
+                {
                     'enrollment_list' : {
                         0: {
                             'group_id' : this.form.id,
@@ -122,10 +123,10 @@ export default {
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params;
                 this.form.reset();
-                if (typeof (params) !== 'undefined'){
+                if (typeof (params) !== 'undefined') {
                     this.form.populate(params);
                     this.method = 'post';
                 }

--- a/resources/js/components/user/UserModal.vue
+++ b/resources/js/components/user/UserModal.vue
@@ -122,14 +122,13 @@ import {useGlobalStore} from "../../store/global";
 
 export default {
     name: 'user-modal',
-    components:{
-    },
+    components: {},
     props: {
         params: {
             type: Object
         },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
     },
-    setup () { //use database store
+    setup() { //use database store
         const globalStore = useGlobalStore();
 
         return {
@@ -160,7 +159,7 @@ export default {
                 this.add();
             }
         },
-        add(){
+        add() {
             axios.post(this.url, this.form)
                 .then(r => {
                     this.$eventHub.emit('user-added', r.data);
@@ -177,18 +176,18 @@ export default {
                 .catch(e => {
                     console.log(e.response);
                 });
-        }
+        },
     },
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params;
 
                 this.form.reset();
-                if (typeof (params) !== 'undefined'){
+                if (typeof (params) !== 'undefined') {
                     this.form.populate(params);
-                    if (this.form.id != ''){
+                    if (this.form.id != '') {
                         this.method = 'patch';
                     } else {
                         this.method = 'post';

--- a/resources/js/components/videoconference/SubscribeVideoconferenceModal.vue
+++ b/resources/js/components/videoconference/SubscribeVideoconferenceModal.vue
@@ -62,11 +62,11 @@ import {useGlobalStore} from "../../store/global";
 
 export default {
     name: 'subscribe-videoconference-modal',
-    components:{
+    components: {
         Select2
     },
     props: {},
-    setup () {
+    setup() {
         const globalStore = useGlobalStore();
         return {
             globalStore,
@@ -105,12 +105,12 @@ export default {
     mounted() {
         this.globalStore.registerModal(this.$options.name);
         this.globalStore.$subscribe((mutation, state) => {
-            if (mutation.events.key === this.$options.name){
+            if (state.modals[this.$options.name].show) {
                 const params = state.modals[this.$options.name].params.reference;
                 this.subscribable_type = state.modals[this.$options.name].params.subscribable_type;
                 this.subscribable_id = state.modals[this.$options.name].params.subscribable_id;
                 this.form.reset();
-                if (typeof (params) !== 'undefined'){
+                if (typeof (params) !== 'undefined') {
                     this.form.populate(params);
                     this.method = 'post';
                 }

--- a/resources/js/components/videoconference/VideoconferenceModal.vue
+++ b/resources/js/components/videoconference/VideoconferenceModal.vue
@@ -510,205 +510,203 @@
     </Transition>
 </template>
 <script>
-    import Form from 'form-backend-validation';
-    import MediumModal from "../media/MediumModal.vue";
-    import MediumForm from "../media/MediumForm.vue";
-    import axios from "axios";
-    import Editor from "@tinymce/tinymce-vue";
-    import Select2 from "../forms/Select2.vue";
-    import {useGlobalStore} from "../../store/global";
+import Form from 'form-backend-validation';
+import MediumModal from "../media/MediumModal.vue";
+import MediumForm from "../media/MediumForm.vue";
+import axios from "axios";
+import Editor from "@tinymce/tinymce-vue";
+import Select2 from "../forms/Select2.vue";
+import {useGlobalStore} from "../../store/global";
 
-    export default {
-        name: 'videoconference-modal',
-        components:{
-            Editor,
-            MediumModal,
-            Select2,
-            MediumForm
-        },
-        props: {
-            params: {
-                type: Object
-            },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
-
-        },
-        setup () {
-            const globalStore = useGlobalStore();
-            return {
-                globalStore,
-            }
-        },
-        data() {
-            return {
-                component_id: this.$.uid,
-                method: 'post',
-                url: '/videoconferences',
-                form: new Form({
-                    'id': '',
-                    'meetingID': '',
-                    'meetingName': '',
-                    'attendeePW': '',
-                    'moderatorPW': '',
-                    'endCallbackUrl': '',
-                    'welcomeMessage': '',
-                    'dialNumber': null,
-                    'maxParticipants': 0,
-                    'logoutUrl': '',
-                    'record': false,
-                    'duration': 0,
-                    'isBreakout': false,
-                    'moderatorOnlyMessage': '',
-                    'autoStartRecording': false,
-                    'allowStartStopRecording': true,
-                    'bannerText': '',
-                    'bannerColor': '#F2C511',
-                    'logo': null,
-                    'copyright': '',
-                    'muteOnStart': false,
-                    'allowModsToUnmuteUsers': false,
-                    'lockSettingsDisableCam': false,
-                    'lockSettingsDisableMic': false,
-                    'lockSettingsDisablePrivateChat': false,
-                    'lockSettingsDisablePublicChat': false,
-                    'lockSettingsDisableNote': false,
-                    'lockSettingsLockedLayout': false,
-                    'lockSettingsLockOnJoin': false,
-                    'lockSettingsLockOnJoinConfigurable': false,
-                    'guestPolicy': 'ALWAYS_ACCEPT',
-                    'userName': '',
-                    'meetingKeepEvents': false,
-                    'endWhenNoModerator': false,
-                    'endWhenNoModeratorDelayInMinutes': 1,
-                    'meetingLayout': 'SMART_LAYOUT',
-                    'learningDashboardCleanupDelayInMinutes': 2,
-                    'allowModsToEjectCameras': false,
-                    'allowRequestsWithoutSession': false,
-                    'userCameraCap': 3,
-                    'allJoinAsModerator': false,
-                    'medium_id': null,
-                    'webcamsOnlyForModerator': false,
-                    'anyoneCanStart': false,
-                    'server': 'server1'
-                }),
-                askModerator: true,
-                servers: {},
-
-                tinyMCE: this.$initTinyMCE(
-                    [
-                        "autolink link table lists"
-                    ],
-                    {
-                        'eventHubCallbackFunction': 'insertContent',
-                        'eventHubCallbackFunctionParams': this.component_id,
-                    }
-                ),
-                showExtendedSettings: false,
-                guestPolicyConstants: {
-                    0: {
-                        'id': 'ALWAYS_ACCEPT',
-                        'text': window.trans.global.videoconference.ALWAYS_ACCEPT,
-                    },
-                    1: {
-                        'id': 'ALWAYS_DENY',
-                        'text': window.trans.global.videoconference.ALWAYS_DENY,
-                    },
-                    2: {
-                        'id': 'ASK_MODERATOR',
-                        'text': window.trans.global.videoconference.ASK_MODERATOR
-                    }
+export default {
+    name: 'videoconference-modal',
+    components: {
+        Editor,
+        MediumModal,
+        Select2,
+        MediumForm
+    },
+    props: {
+        params: {
+            type: Object
+        },  //{ 'modelId': curriculum.id, 'modelUrl': 'curriculum' , 'shareWithToken': true, 'canEditCheckbox': false}
+    },
+    setup() {
+        const globalStore = useGlobalStore();
+        return {
+            globalStore,
+        }
+    },
+    data() {
+        return {
+            component_id: this.$.uid,
+            method: 'post',
+            url: '/videoconferences',
+            form: new Form({
+                'id': '',
+                'meetingID': '',
+                'meetingName': '',
+                'attendeePW': '',
+                'moderatorPW': '',
+                'endCallbackUrl': '',
+                'welcomeMessage': '',
+                'dialNumber': null,
+                'maxParticipants': 0,
+                'logoutUrl': '',
+                'record': false,
+                'duration': 0,
+                'isBreakout': false,
+                'moderatorOnlyMessage': '',
+                'autoStartRecording': false,
+                'allowStartStopRecording': true,
+                'bannerText': '',
+                'bannerColor': '#F2C511',
+                'logo': null,
+                'copyright': '',
+                'muteOnStart': false,
+                'allowModsToUnmuteUsers': false,
+                'lockSettingsDisableCam': false,
+                'lockSettingsDisableMic': false,
+                'lockSettingsDisablePrivateChat': false,
+                'lockSettingsDisablePublicChat': false,
+                'lockSettingsDisableNote': false,
+                'lockSettingsLockedLayout': false,
+                'lockSettingsLockOnJoin': false,
+                'lockSettingsLockOnJoinConfigurable': false,
+                'guestPolicy': 'ALWAYS_ACCEPT',
+                'userName': '',
+                'meetingKeepEvents': false,
+                'endWhenNoModerator': false,
+                'endWhenNoModeratorDelayInMinutes': 1,
+                'meetingLayout': 'SMART_LAYOUT',
+                'learningDashboardCleanupDelayInMinutes': 2,
+                'allowModsToEjectCameras': false,
+                'allowRequestsWithoutSession': false,
+                'userCameraCap': 3,
+                'allJoinAsModerator': false,
+                'medium_id': null,
+                'webcamsOnlyForModerator': false,
+                'anyoneCanStart': false,
+                'server': 'server1'
+            }),
+            askModerator: true,
+            servers: {},
+            tinyMCE: this.$initTinyMCE(
+                [
+                    "autolink link table lists"
+                ],
+                {
+                    'eventHubCallbackFunction': 'insertContent',
+                    'eventHubCallbackFunctionParams': this.component_id,
+                }
+            ),
+            showExtendedSettings: false,
+            guestPolicyConstants: {
+                0: {
+                    'id': 'ALWAYS_ACCEPT',
+                    'text': window.trans.global.videoconference.ALWAYS_ACCEPT,
                 },
-                meetingLayoutConstants: {
-                    0: {
-                        'id': 'SMART_LAYOUT',
-                        'text': window.trans.global.videoconference.SMART_LAYOUT,
-                    },
-                    1: {
-                        'id': 'CUSTOM_LAYOUT',
-                        'text': window.trans.global.videoconference.CUSTOM_LAYOUT,
-                    },
-                    2: {
-                        'id': 'PRESENTATION_FOCUS',
-                        'text': window.trans.global.videoconference.PRESENTATION_FOCUS,
-                    },
-                    3: {
-                        'id': 'VIDEO_FOCUS',
-                        'text': window.trans.global.videoconference.VIDEO_FOCUS
-                    },
+                1: {
+                    'id': 'ALWAYS_DENY',
+                    'text': window.trans.global.videoconference.ALWAYS_DENY,
+                },
+                2: {
+                    'id': 'ASK_MODERATOR',
+                    'text': window.trans.global.videoconference.ASK_MODERATOR
                 }
+            },
+            meetingLayoutConstants: {
+                0: {
+                    'id': 'SMART_LAYOUT',
+                    'text': window.trans.global.videoconference.SMART_LAYOUT,
+                },
+                1: {
+                    'id': 'CUSTOM_LAYOUT',
+                    'text': window.trans.global.videoconference.CUSTOM_LAYOUT,
+                },
+                2: {
+                    'id': 'PRESENTATION_FOCUS',
+                    'text': window.trans.global.videoconference.PRESENTATION_FOCUS,
+                },
+                3: {
+                    'id': 'VIDEO_FOCUS',
+                    'text': window.trans.global.videoconference.VIDEO_FOCUS
+                },
+            }
+        }
+    },
+    computed: {
+        textColor: function() {
+            return this.$textcolor(this.form.color, '#333333');
+        }
+    },
+    methods: {
+        submit(method) {
+            if (this.showExtendedSettings === true) {
+                this.form.welcomeMessage = tinyMCE.get('welcomeMessage').getContent();
+                this.form.moderatorOnlyMessage = tinyMCE.get('moderatorOnlyMessage').getContent();
+            }
+
+            if (this.askModerator === true) {
+                this.form.guestPolicy = 'ASK_MODERATOR';
+            } else {
+                this.form.guestPolicy = 'ALWAYS_ACCEPT';
+            }
+            if (method === 'patch') {
+                this.update();
+            } else {
+                this.add();
             }
         },
-        computed:{
-            textColor: function(){
-                return this.$textcolor(this.form.color, '#333333');
-            }
-        },
-        methods: {
-             submit(method) {
-                 if (this.showExtendedSettings === true){
-                     this.form.welcomeMessage = tinyMCE.get('welcomeMessage').getContent();
-                     this.form.moderatorOnlyMessage = tinyMCE.get('moderatorOnlyMessage').getContent();
-                 }
-
-                 if (this.askModerator === true) {
-                     this.form.guestPolicy = 'ASK_MODERATOR';
-                 } else {
-                     this.form.guestPolicy = 'ALWAYS_ACCEPT';
-                 }
-                 if (method === 'patch') {
-                     this.update();
-                 } else {
-                     this.add();
-                 }
-            },
-            add(){
-                axios.post(this.url, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('videoconference-added', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-            update() {
-                axios.patch(this.url + '/' + this.form.id, this.form)
-                    .then(r => {
-                        this.$eventHub.emit('videoconference-updated', r.data);
-                    })
-                    .catch(e => {
-                        console.log(e.response);
-                    });
-            },
-        },
-        mounted() {
-            this.globalStore.registerModal(this.$options.name);
-            this.globalStore.$subscribe((mutation, state) => {
-                if (mutation.events.key === this.$options.name){
-                    const params = state.modals[this.$options.name].params;
-
-                    this.form.reset();
-                    if (typeof (params) !== 'undefined'){
-                        this.form.populate(params);
-                        this.form.guestPolicy = params.guestPolicy === 'ASK_MODERATOR';
-                        this.askModerator = (params.guestPolicy === 'ASK_MODERATOR') ? true : false;
-
-                        if (this.form.id !== ''){
-                            this.form.welcomeMessage = this.$decodeHtml(this.form.welcomeMessage);
-                            this.form.moderatorOnlyMessage = this.$decodeHtml(this.form.moderatorOnlyMessage);
-                            this.method = 'patch';
-                        } else {
-                            this.method = 'post';
-                        }
-                    }
-                }
-            });
-
-            axios.get('/videoconferences/servers')
-                .then(response => {
-                    this.servers = response.data;
+        add() {
+            axios.post(this.url, this.form)
+                .then(r => {
+                    this.$eventHub.emit('videoconference-added', r.data);
                 })
                 .catch(e => {
-                    console.log(e);
+                    console.log(e.response);
                 });
         },
-    }
+        update() {
+            axios.patch(this.url + '/' + this.form.id, this.form)
+                .then(r => {
+                    this.$eventHub.emit('videoconference-updated', r.data);
+                })
+                .catch(e => {
+                    console.log(e.response);
+                });
+        },
+    },
+    mounted() {
+        this.globalStore.registerModal(this.$options.name);
+        this.globalStore.$subscribe((mutation, state) => {
+            if (state.modals[this.$options.name].show) {
+                const params = state.modals[this.$options.name].params;
+
+                this.form.reset();
+                if (typeof (params) !== 'undefined') {
+                    this.form.populate(params);
+                    this.form.guestPolicy = params.guestPolicy === 'ASK_MODERATOR';
+                    this.askModerator = (params.guestPolicy === 'ASK_MODERATOR') ? true : false;
+
+                    if (this.form.id !== '') {
+                        this.form.welcomeMessage = this.$decodeHtml(this.form.welcomeMessage);
+                        this.form.moderatorOnlyMessage = this.$decodeHtml(this.form.moderatorOnlyMessage);
+                        this.method = 'patch';
+                    } else {
+                        this.method = 'post';
+                    }
+                }
+            }
+        });
+
+        axios.get('/videoconferences/servers')
+            .then(response => {
+                this.servers = response.data;
+            })
+            .catch(e => {
+                console.log(e);
+            });
+    },
+}
 </script>


### PR DESCRIPTION
literally every modal-file has been formatted, which caused the ~3000 added/deleted lines

- removed every used mutation.events.key and replaced it with state.modals[this.$options.name]
- updated 'preview'-command so it runs sequentially
- fixed eventHub events in logbook

IMPORTANT:
in the DB, the 'logbook_entries.begin' column isn't set to nullable
-> this was fixed in a commit for the old-version, but this hasn't been transferred yet
-> to reduce duplication, this should be done manually in the DEV environment