### PR TITLE
Kanban changes

### DIFF
--- a/app/Plugins/Repositories/edusharing/resources/js/components/Create.vue
+++ b/app/Plugins/Repositories/edusharing/resources/js/components/Create.vue
@@ -28,7 +28,7 @@
                     :src="this.uploadIframeUrl"
                     :width="this.width"
                     :height="this.height"
-                    style="height: 80vh;"
+                    style="height: 60vh;"
                     frameborder="0"
                 >
                 </iframe>

--- a/resources/js/components/kanban/Kanban.vue
+++ b/resources/js/components/kanban/Kanban.vue
@@ -54,53 +54,57 @@
                                 filter=".ignore"
                             />
                             <div
-                                style="margin-top: 15px; bottom: 0; overflow-y: scroll; z-index: 1"
                                 :style="'width:' + itemWidth + 'px;'"
-                                class="hide-scrollbars pr-3"
+                                class="pr-3"
                             >
-                                <draggable
-                                    :list="status.items"
-                                    v-bind="itemDragOptions"
-                                    :move="isLocked"
-                                    @end="syncItemMoved"
-                                    handle=".handle"
-                                    item-key="kanban_status_id"
-                                    :component-data="{ name: 'fade' }"
-                                >
-                                    <template
-                                        #item="{ element: item, itemIndex }"
-                                        :style="'width:' + itemWidth + 'px;'"
-                                        class="d-flex flex-column pr-3"
-                                    >
-                                        <span :key="'item_' + item.id">
-                                            <KanbanItem
-                                                v-if=" (item.visibility && visiblefrom_to(item.visible_from, item.visible_until) == true)
-                                                    || ($userId == item.owner_id)
-                                                    || ($userId == kanban.owner_id)"
-                                                :key="item.id"
-                                                :editable="(status.editable == false && $userId != kanban.owner_id) ? false : editable"
-                                                :commentable="kanban.commentable"
-                                                :onlyEditOwnedItems="kanban.only_edit_owned_items"
-                                                :ref="'kanbanItemId' + item.id"
-                                                :index="status.id + '_' + item.id"
-                                                :item="item"
-                                                :width="itemWidth"
-                                                :kanban_owner_id="kanban.owner_id"
-                                                style="min-height: 150px"
-                                                v-on:item-edit=""
-                                                v-on:sync="sync"
-                                                filter=".ignore"
-                                            />
-                                        </span>
-
-                                    </template>
-                                </draggable>
                                 <div v-if="(editable && status.editable) || ($userId == status.owner_id)"
                                     :id="'kanbanItemCreateButton_' + index"
-                                    class="btn btn-flat mb-3 py-0 w-100"
+                                    class="btn btn-flat py-2 w-100"
                                     @click="openItemModal(status.id)"
                                 >
                                     <i class="text-white fa fa-2x fa-plus-circle"></i>
+                                </div>
+                                <div
+                                    class="hide-scrollbars"
+                                    style="height: 100svh; overflow-y: scroll; padding-bottom: 360px;"
+                                >
+                                    <draggable
+                                        :list="status.items"
+                                        v-bind="itemDragOptions"
+                                        :move="isLocked"
+                                        @end="syncItemMoved"
+                                        handle=".handle"
+                                        item-key="kanban_status_id"
+                                        :component-data="{ name: 'fade' }"
+                                    >
+                                        <template
+                                            #item="{ element: item, itemIndex }"
+                                            :style="'width:' + itemWidth + 'px;'"
+                                            class="d-flex flex-column pr-3"
+                                        >
+                                            <span :key="'item_' + item.id">
+                                                <KanbanItem
+                                                    v-if=" (item.visibility && visiblefrom_to(item.visible_from, item.visible_until) == true)
+                                                        || ($userId == item.owner_id)
+                                                        || ($userId == kanban.owner_id)"
+                                                    :key="item.id"
+                                                    :editable="(status.editable == false && $userId != kanban.owner_id) ? false : editable"
+                                                    :commentable="kanban.commentable"
+                                                    :onlyEditOwnedItems="kanban.only_edit_owned_items"
+                                                    :ref="'kanbanItemId' + item.id"
+                                                    :index="status.id + '_' + item.id"
+                                                    :item="item"
+                                                    :width="itemWidth"
+                                                    :kanban_owner_id="kanban.owner_id"
+                                                    style="min-height: 150px"
+                                                    v-on:item-edit=""
+                                                    v-on:sync="sync"
+                                                    filter=".ignore"
+                                                />
+                                            </span>
+    
+                                        </template>
+                                    </draggable>
                                 </div>
                             </div>
                         </span>
@@ -633,11 +637,12 @@ export default {
 }
 .content-only .kanban_board_container { width: calc(100vw - 1rem); }
 .kanban_board_wrapper {
-    position:absolute;
+    position: absolute;
     height: 100%;
     width: 100%;
     padding: 2rem;
-    overflow:auto;
+    overflow-x: overlay;
+    overflow-y: clip;
 }
 @media (max-width: 991px) {
     .kanban_board_container { width: calc(100vw - 30px) !important; }

--- a/resources/js/components/kanban/Kanban.vue
+++ b/resources/js/components/kanban/Kanban.vue
@@ -33,15 +33,15 @@
                 handle=".handle"
                 item-key="id"
                 :emptyInsertThreshold="500"
-                class="d-flex m-0 pr-4 h-100"
-                :style="kanbanWidth"
+                class="d-flex m-0 h-100"
+                style="width: max-content; gap: 16px; padding-right: 2rem"
             >
                 <template
                     #item="{ element: status , index }"
                 >
                     <span v-if="(status.visibility) || ($userId == status.owner_id)"
                         :key="'drag_status_' + status.id"
-                        class="d-flex flex-column pr-3 h-100"
+                        class="d-flex flex-column h-100"
                         :style="'width:' + itemWidth + 'px;'"
                     >
                         <KanbanStatus

--- a/resources/js/components/kanban/Kanban.vue
+++ b/resources/js/components/kanban/Kanban.vue
@@ -104,7 +104,7 @@
                 </template>
                 <template #footer>
                     <div v-if="editable"
-                        class=" no-border float-left pr-2"
+                        class="no-border float-left pr-2"
                         :style="'width:' + itemWidth + 'px;'"
                     >
                         <KanbanStatus

--- a/resources/js/components/kanban/Kanban.vue
+++ b/resources/js/components/kanban/Kanban.vue
@@ -53,7 +53,7 @@
                         />
                         <div v-if="(editable && status.editable) || ($userId == status.owner_id)"
                             :id="'kanbanItemCreateButton_' + index"
-                            class="btn btn-flat py-2 w-100"
+                            class="btn btn-flat p-1 my-1 mx-auto"
                             @click="openItemModal(status.id)"
                         >
                             <i class="text-white fa fa-2x fa-plus-circle"></i>

--- a/resources/js/components/kanban/Kanban.vue
+++ b/resources/js/components/kanban/Kanban.vue
@@ -24,105 +24,97 @@
             >
                 <i class="fa fa-expand"></i>
             </div>
-            <div
+            <!-- Columns (Statuses) -->
+            <draggable
+                v-model="statuses"
+                v-bind="columnDragOptions"
+                :move="isLocked"
+                @end="syncStatusMoved"
+                handle=".handle"
+                item-key="id"
+                :emptyInsertThreshold="500"
+                class="d-flex m-0 h-100"
                 :style="kanbanWidth"
-                class="m-0"
             >
-                <!-- Columns (Statuses) -->
-                <draggable
-                    v-model="statuses"
-                    v-bind="columnDragOptions"
-                    :move="isLocked"
-                    @end="syncStatusMoved"
-                    handle=".handle"
-                    item-key="id"
-                    :emptyInsertThreshold="500"
+                <template
+                    #item="{ element: status , index }"
                 >
-                    <template
-                        #item="{ element: status , index }"
+                    <span v-if="(status.visibility) || ($userId == status.owner_id)"
+                        :key="'drag_status_' + status.id"
+                        class="d-flex flex-column pr-3 h-100"
+                        :style="'width:' + itemWidth + 'px;'"
                     >
-                        <span v-if="(status.visibility) || ($userId == status.owner_id)"
-                            :key="'drag_status_' + status.id"
-                            class="no-border float-left pr-3"
-                            :style="'width:' + itemWidth + 'px;'"
+                        <KanbanStatus
+                            :kanban="kanban"
+                            :status="status"
+                            :editable="editable"
+                            :key="status.id"
+                            filter=".ignore"
+                        />
+                        <div v-if="(editable && status.editable) || ($userId == status.owner_id)"
+                            :id="'kanbanItemCreateButton_' + index"
+                            class="btn btn-flat py-2 w-100"
+                            @click="openItemModal(status.id)"
                         >
-                            <KanbanStatus
-                                :kanban="kanban"
-                                :status="status"
-                                :editable="editable"
-                                :key="status.id"
-                                filter=".ignore"
-                            />
-                            <div
-                                :style="'width:' + itemWidth + 'px;'"
-                                class="pr-3"
-                            >
-                                <div v-if="(editable && status.editable) || ($userId == status.owner_id)"
-                                    :id="'kanbanItemCreateButton_' + index"
-                                    class="btn btn-flat py-2 w-100"
-                                    @click="openItemModal(status.id)"
-                                >
-                                    <i class="text-white fa fa-2x fa-plus-circle"></i>
-                                </div>
-                                <div
-                                    class="hide-scrollbars"
-                                    style="height: 100svh; overflow-y: scroll; padding-bottom: 360px;"
-                                >
-                                    <draggable
-                                        :list="status.items"
-                                        v-bind="itemDragOptions"
-                                        :move="isLocked"
-                                        @end="syncItemMoved"
-                                        handle=".handle"
-                                        item-key="kanban_status_id"
-                                        :component-data="{ name: 'fade' }"
-                                    >
-                                        <template
-                                            #item="{ element: item, itemIndex }"
-                                            :style="'width:' + itemWidth + 'px;'"
-                                            class="d-flex flex-column pr-3"
-                                        >
-                                            <span :key="'item_' + item.id">
-                                                <KanbanItem
-                                                    v-if=" (item.visibility && visiblefrom_to(item.visible_from, item.visible_until) == true)
-                                                        || ($userId == item.owner_id)
-                                                        || ($userId == kanban.owner_id)"
-                                                    :key="item.id"
-                                                    :editable="(status.editable == false && $userId != kanban.owner_id) ? false : editable"
-                                                    :commentable="kanban.commentable"
-                                                    :onlyEditOwnedItems="kanban.only_edit_owned_items"
-                                                    :ref="'kanbanItemId' + item.id"
-                                                    :index="status.id + '_' + item.id"
-                                                    :item="item"
-                                                    :width="itemWidth"
-                                                    :kanban_owner_id="kanban.owner_id"
-                                                    style="min-height: 150px"
-                                                    v-on:item-edit=""
-                                                    v-on:sync="sync"
-                                                    filter=".ignore"
-                                                />
-                                            </span>
-    
-                                        </template>
-                                    </draggable>
-                                </div>
-                            </div>
-                        </span>
-                    </template>
-                    <template #footer>
-                        <div v-if="editable"
-                            class=" no-border float-left pr-2"
-                            :style="'width:' + itemWidth + 'px;'"
-                        >
-                            <KanbanStatus
-                                :kanban="kanban"
-                                :editable="editable"
-                                :newStatus=true
-                            />
+                            <i class="text-white fa fa-2x fa-plus-circle"></i>
                         </div>
-                    </template>
-                </draggable>
-            </div>
+                        <div v-else class="py-2"></div>
+                        <div
+                            class="hide-scrollbars"
+                            style="overflow-y: scroll;"
+                        >
+                            <draggable
+                                :list="status.items"
+                                v-bind="itemDragOptions"
+                                :move="isLocked"
+                                @end="syncItemMoved"
+                                handle=".handle"
+                                item-key="kanban_status_id"
+                                :component-data="{ name: 'fade' }"
+                            >
+                                <template
+                                    #item="{ element: item, itemIndex }"
+                                    :style="'width:' + itemWidth + 'px;'"
+                                    class="d-flex flex-column pr-3"
+                                >
+                                    <span :key="'item_' + item.id">
+                                        <KanbanItem
+                                            v-if=" (item.visibility && visiblefrom_to(item.visible_from, item.visible_until) == true)
+                                                || ($userId == item.owner_id)
+                                                || ($userId == kanban.owner_id)"
+                                            :key="item.id"
+                                            :editable="(status.editable == false && $userId != kanban.owner_id) ? false : editable"
+                                            :commentable="kanban.commentable"
+                                            :onlyEditOwnedItems="kanban.only_edit_owned_items"
+                                            :ref="'kanbanItemId' + item.id"
+                                            :index="status.id + '_' + item.id"
+                                            :item="item"
+                                            :width="itemWidth"
+                                            :kanban_owner_id="kanban.owner_id"
+                                            style="min-height: 150px"
+                                            v-on:item-edit=""
+                                            v-on:sync="sync"
+                                            filter=".ignore"
+                                        />
+                                    </span>
+                                </template>
+                            </draggable>
+                        </div>
+                    </span>
+                </template>
+                <template #footer>
+                    <div v-if="editable"
+                        class=" no-border float-left pr-2"
+                        :style="'width:' + itemWidth + 'px;'"
+                    >
+                        <KanbanStatus
+                            :kanban="kanban"
+                            :editable="editable"
+                            :newStatus=true
+                        />
+                    </div>
+                </template>
+            </draggable>
         </div>
     </div>
     <Teleport to="body">

--- a/resources/js/components/kanban/Kanban.vue
+++ b/resources/js/components/kanban/Kanban.vue
@@ -33,7 +33,7 @@
                 handle=".handle"
                 item-key="id"
                 :emptyInsertThreshold="500"
-                class="d-flex m-0 h-100"
+                class="d-flex m-0 pr-4 h-100"
                 :style="kanbanWidth"
             >
                 <template

--- a/resources/js/components/kanban/Kanban.vue
+++ b/resources/js/components/kanban/Kanban.vue
@@ -91,7 +91,6 @@
                                             :item="item"
                                             :width="itemWidth"
                                             :kanban_owner_id="kanban.owner_id"
-                                            style="min-height: 150px"
                                             v-on:item-edit=""
                                             v-on:sync="sync"
                                             filter=".ignore"

--- a/resources/js/components/kanban/KanbanStatus.vue
+++ b/resources/js/components/kanban/KanbanStatus.vue
@@ -1,7 +1,8 @@
 <template>
-    <div class="card-header border-bottom-0 p-0 kanban-header">
+    <div class="kanban-header">
         <div v-if="newStatus === true"
             id="kanbanStatusCreate"
+            class="d-flex align-items-center"
         >
             <strong
                 class="text-secondary btn px-1 py-0"
@@ -10,9 +11,7 @@
                 <i class="fa fa-plus"></i> {{ trans('global.kanbanStatus.create') }}
             </strong>
         </div>
-        
-        <div v-else>
-            <strong>{{ status.title }}</strong>
+        <div v-else class="d-flex align-items-center">
             <div v-if="($userId == kanban.owner_id)
                     || (editable && $userId == status.owner_id)
                     || (editable && status.editable && !kanban.only_edit_owned_items)"
@@ -50,17 +49,18 @@
                     </div>
                 </div>
             </div>
+            <strong>{{ status.title }}</strong>
             <div v-if="$userId == kanban.owner_id
                     || (!status.locked || $userId == status.owner_id)"
-                class="pull-right handle pointer"
+                class="handle ml-auto pointer"
             >
-                <span class="fa-stack fa-1x">
+                <span class="position-relative">
                     <i v-if="editable"
-                        class="fa-solid fa-arrows-up-down-left-right fa-stack-1x"
+                        class="fa fa-arrows-up-down-left-right"
                     ></i>
                     <i v-if="status.locked"
-                        class="fa-solid fa-lock fa-stack-1x text-muted"
-                        style="left: 10px; top: 10px;"
+                        class="fa fa-lock text-muted position-absolute"
+                        style="left: 8px; top: 10px;"
                     ></i>
                 </span>
             </div>

--- a/resources/js/components/kanban/KanbanStatusModal.vue
+++ b/resources/js/components/kanban/KanbanStatusModal.vue
@@ -183,7 +183,7 @@ export default {
                 visibility: true,
                 visible_from: null,
                 visible_until: null,
-                color:'#27AF60',
+                color: '#f4f4f4',
             }),
         }
     },

--- a/resources/js/components/kanbanItem/KanbanItem.vue
+++ b/resources/js/components/kanbanItem/KanbanItem.vue
@@ -1,7 +1,30 @@
 <template>
-    <div class="card">
-        <div class="card-header px-3 py-2" :style="{ backgroundColor: item.color, color: textColor }">
-            <div class="card-tools">
+    <div
+        :id="'item-' + item.id"
+        class="card"
+    >
+        <div
+            class="card-header p-0"
+            :style="{ color: textColor }"
+            data-toggle="collapse"
+            :data-target="'#item-' + item.id + ' > .card-body'"
+            aria-expanded="true"
+        >
+            <div
+                class="card-header-title pl-3 py-2 w-100"
+                :style="{ backgroundColor: item.color }"
+                style="max-width: 100%; padding-right: 50px; border-top-left-radius: 0.25rem; border-top-right-radius: 0.25rem;"
+            >
+                {{ item.title }}
+                <i class="fa fa-angle-up"></i>
+                <div style="font-size: .5rem">
+                    {{ item.created_at }}
+                </div>
+            </div>
+            <div
+                class="card-tools position-absolute"
+                style="top: 8px; right: 16px;"
+            >
                 <div v-if="$userId == kanban_owner_id
                         || (editable && $userId == item.owner_id)
                         || (editable && item.editable && onlyEditOwnedItems == false)"
@@ -14,7 +37,10 @@
                     <i class="fas fa-ellipsis-v"
                        :style="{ 'text-color': textColor }"
                     ></i>
-                    <div class="dropdown-menu" x-placement="top-start">
+                    <div
+                        class="dropdown-menu"
+                        x-placement="top-start"
+                    >
                         <button
                             :name="'kanbanItemEdit_'+index"
                             class="dropdown-item text-secondary py-1"
@@ -54,30 +80,17 @@
                     ></i>
                 </div>
             </div>
-            <div class="pb-0">
-                <div>
-                    {{ item.title }}
-                    <div
-                        class="clearfix"
-                        style="font-size: .5rem"
-                    >
-                        {{ item.created_at }}
-                    </div>
-                </div>
-            </div>
         </div>
 
-        <div class="card-body p-0">
+        <div class="card-body p-0 collapse show">
             <div>
-                <div v-if="item.description !== null"
-                    class="text-muted small px-3 py-2"
-                >
+                <div class="text-muted small px-3 py-2">
                     <span v-if="item.replace_links">
                         <HtmlRenderer
-                            :html-content="item.description"
+                            :html-content="item.description ?? '</br>'"
                         ></HtmlRenderer>
                     </span>
-                    <span v-else v-dompurify-html="item.description"></span>
+                    <span v-else v-dompurify-html="item.description ?? '</br>'"></span>
                 </div>
             </div>
             <mediaCarousel
@@ -135,10 +148,10 @@
 
                 <span class="d-flex flex-fill"></span>
                 <div v-if="commentable"
-                    class=" position-relative pull-right mr-2"
+                    class="mr-2 px-1 pointer"
                     @click="openComments"
                 >
-                    <i class="far fa-comments pointer with-comment-count"></i>
+                    <i class="far fa-comments"></i>
                     <span v-if="item.comments.length > 0"
                         class="comment-count mt-1 small bg-success"
                     >
@@ -357,4 +370,7 @@ export default {
     line-height: 11px;
     vertical-align: middle;
 }
+.card-header-title:hover { filter: brightness(90%); }
+.fa-angle-up { transition: 0.4s transform; }
+.collapsed .fa-angle-up { transform: rotate(-180deg); }
 </style>

--- a/resources/js/components/kanbanItem/KanbanItem.vue
+++ b/resources/js/components/kanbanItem/KanbanItem.vue
@@ -17,7 +17,7 @@
                     <div class="dropdown-menu" x-placement="top-start">
                         <button
                             :name="'kanbanItemEdit_'+index"
-                            class="dropdown-item text-secondary  py-1"
+                            class="dropdown-item text-secondary py-1"
                             @click="edit()"
                         >
                             <i class="fa fa-pencil-alt mr-2"></i>

--- a/resources/js/components/kanbanItem/KanbanItem.vue
+++ b/resources/js/components/kanbanItem/KanbanItem.vue
@@ -149,12 +149,12 @@
 
                 <span class="d-flex flex-fill"></span>
                 <div v-if="commentable"
-                    class="mr-2 px-1 pointer"
+                    class="position-relative mr-2 px-1 pointer"
                     @click="openComments"
                 >
                     <i class="far fa-comments"></i>
                     <span v-if="item.comments.length > 0"
-                        class="comment-count mt-1 small bg-success"
+                        class="comment-count bg-success"
                     >
                         {{ item.comments.length }}
                     </span>

--- a/resources/js/components/kanbanItem/KanbanItem.vue
+++ b/resources/js/components/kanbanItem/KanbanItem.vue
@@ -74,6 +74,7 @@
                 </div>
                 <div v-if="(!item.locked || $userId == item.owner_id) || $userId == kanban_owner_id"
                     class="float-right py-0 px-1 mx-1 handle pointer"
+                    @click.stop
                 >
                     <i class="fa fa-arrows-up-down-left-right"
                        :style="{ 'text-color': textColor }"

--- a/resources/js/components/kanbanItem/KanbanItemModal.vue
+++ b/resources/js/components/kanbanItem/KanbanItemModal.vue
@@ -215,7 +215,7 @@ export default {
                 kanban_id: '',
                 kanban_status_id: '',
                 order_id: 0,
-                color: '#27AF60',
+                color: '#f4f4f4',
                 due_date: '',
                 locked: false,
                 editable: true,

--- a/resources/js/components/media/MediumModal.vue
+++ b/resources/js/components/media/MediumModal.vue
@@ -77,10 +77,7 @@
                         </div>
                         <!-- /.left-menu -->
 
-                        <div
-                            class="p-1 flex-fill border-left"
-                            style="min-height: 550px"
-                        >
+                        <div class="p-1 flex-fill border-left">
                             <div class="tab-content p-2">
                                 <div
                                     v-permission="'medium_create'"

--- a/resources/js/components/reaction/Reaction.vue
+++ b/resources/js/components/reaction/Reaction.vue
@@ -1,12 +1,14 @@
 <template>
     <div
        @click="toggle()"
-       class="position-relative pull-right">
-
+       class="px-1 pointer"
+    >
         <i  v-if="userHasReaction()"
-           class="fa fa-heart pointer with-comment-count"></i>
+           class="fa fa-heart"
+        ></i>
         <i v-else
-           class="far fa-heart pointer with-comment-count"></i>
+           class="far fa-heart"
+        ></i>
         <span v-if=" this.likes  !== null">
             <span v-if="likes_count > 0"
                 class="comment-count mt-1 small bg-success"
@@ -34,7 +36,7 @@ export default {
         };
     },
     methods: {
-        toggle(){
+        toggle() {
             axios.post(this.url + "/" + this.model.id + "/react", {
                 'reaction': this.likes,
             })
@@ -45,7 +47,7 @@ export default {
                     console.log(err.response);
                 });
         },
-        userHasReaction(){
+        userHasReaction() {
             if (this.likes.findIndex(l => l.user_id == this.$userId) != -1){
                return true;
             }  else {
@@ -56,11 +58,10 @@ export default {
     mounted() {
       this.likes = this.model.likes;
     },
-    computed:{
-      likes_count() {
-          return this.likes.length;
-      }
-    }
-
+    computed: {
+        likes_count() {
+            return this.likes.length;
+        }
+    },
 }
 </script>

--- a/resources/js/components/reaction/Reaction.vue
+++ b/resources/js/components/reaction/Reaction.vue
@@ -1,7 +1,7 @@
 <template>
     <div
        @click="toggle()"
-       class="px-1 pointer"
+       class="position-relative px-1 pointer"
     >
         <i  v-if="userHasReaction()"
            class="fa fa-heart"
@@ -9,12 +9,10 @@
         <i v-else
            class="far fa-heart"
         ></i>
-        <span v-if=" this.likes  !== null">
-            <span v-if="likes_count > 0"
-                class="comment-count mt-1 small bg-success"
-            >
+        <span v-if="this.likes !== null && likes_count > 0"
+            class="comment-count bg-success"
+        >
             {{ this.likes_count }}
-            </span>
         </span>
     </div>
 </template>

--- a/resources/lang/de/global.php
+++ b/resources/lang/de/global.php
@@ -51,7 +51,7 @@ return [
     'view' => 'Ansicht',
     'edit' => 'editieren',
     'locked' => 'verschieben verhindern',
-    'replace_links' => 'Links ersetzen',
+    'replace_links' => 'Links durch QR-Codes ersetzen',
     'editable' => 'editierbar',
     'delete' => 'löschen',
     'forceDelete' => 'Datensatz endgültig löschen.',

--- a/resources/lang/en/global.php
+++ b/resources/lang/en/global.php
@@ -46,7 +46,7 @@ return [
     'view' => 'View',
     'edit' => 'Edit',
     'locked' => 'locked',
-    'replace_links' => 'Replace links',
+    'replace_links' => 'Replace links with QR-Codes',
     'delete' => 'Delete dataset finally',
     'forceDelete' => '.',
     'save' => 'Save',

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -144,8 +144,8 @@ tr:hover .vuehover {
     background-color: red;
     line-height: 15px;
     color: white;
-    top: -5px;
-    left: 10px;
+    top: -2px;
+    left: 14px;
 }
 .with-comment-count{
     padding-top: 5px;


### PR DESCRIPTION
- Kanban: changed default color on items/status to #f4f4f4 instead of a green tone
- Kanban: put create-item at the top
- Kanban: fixed create-item-button having unproportionally large hitbox
- Kanban: items now scroll instead of the whole Kanban
- Kanban: style changes and removal of unnecessary elements
- Kanban: fixed problems where statuses would have different height/width
- KanbanItem: added collapse-functionality to item-body when clicking on item-header
- KanbanItem: changed structure to avoid unwanted style changes to child-elements on hover
- KanbanItem: fixed position of comments/reactions number
- MediumModal: fixed height
- fixed translation for 'replace_links'